### PR TITLE
✨ [Feat] 메인 페이지 프론트 비즈니스 로직 구현

### DIFF
--- a/src/app/login/page.jsx
+++ b/src/app/login/page.jsx
@@ -41,10 +41,8 @@ export default function Login() {
       formData.append('email', email);
       formData.append('password', password);
 
-      // axiosInstance가 자동으로 Content-Type을 설정하도록 headers는 생략
       const response = await axiosInstance.post('/login', formData);
 
-      // ✅ 헤더에서 access 토큰 추출
       const accessToken =
         response.headers['access'] ||
         response.headers['Access'] ||

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import Header from '@components/common/Header';
+import Banner from '@components/common/Banner';
 import AfterLoginBanner from '@components/common/AfterLoginBanner';
 import SecondBanner from '@components/common/SecondBanner';
 import ReservationSection from '@components/common/ReservationSection';
@@ -18,17 +19,14 @@ export default function Home() {
       try {
         const decoded = jwtDecode(accessToken);
         const { id, email } = decoded;
-
         setUserInfo({ id, email });
         console.log('디코드된 사용자 정보:', decoded);
       } catch (e) {
         console.error('토큰 디코딩 실패:', e);
         alert('토큰이 유효하지 않습니다. 다시 로그인해주세요.');
-        // window.location.href = '/';
       }
     } else {
       console.warn('로그인하지 않은 상태입니다.');
-      // window.location.href = '/';
     }
   }, [accessToken]);
 
@@ -38,7 +36,11 @@ export default function Home() {
         <Header />
       </div>
       <div className="flex justify-center w-full">
-        <AfterLoginBanner className="w-full" />
+        {accessToken ? (
+          <AfterLoginBanner className="w-full" />
+        ) : (
+          <Banner className="w-full" />
+        )}
       </div>
       <div className="flex justify-center w-full">
         <SecondBanner className="w-full" />

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -1,10 +1,23 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
 const Header = () => {
+  const router = useRouter();
+
+  const handleClickProfile = () => {
+    router.push('/my/account-info');
+  };
+
   return (
     <header className="flex justify-between items-center p-4 pt-12">
       <img src="/static/icons/logo.svg" alt="logo" className="h-10" />
       <div className="flex items-center space-x-4">
         <img src="/static/icons/bell_icon.png" alt="bell" className="h-6" />
-        <div className="bg-[#788DFF] rounded-full w-full h-full flex items-center justify-center overflow-hidden">
+        <div
+          className="bg-[#788DFF] rounded-full w-full h-full flex items-center justify-center overflow-hidden cursor-pointer"
+          onClick={handleClickProfile}
+        >
           <img
             src="/static/icons/person_icon.png"
             alt="person_icon"

--- a/src/components/common/ReservationComponent.jsx
+++ b/src/components/common/ReservationComponent.jsx
@@ -1,9 +1,24 @@
+'use client';
+
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import TimeComponent from '@components/common/TimeComponent';
 import Modal from '@components/common/Modal';
+import useTokenStore from '../../stores/useTokenStore';
 
 const ReservationComponent = ({ index }) => {
   const [open, setOpen] = useState(false);
+  const router = useRouter();
+  const { accessToken } = useTokenStore();
+
+  const handleOpenModal = () => {
+    if (!accessToken) {
+      alert('로그인이 필요합니다.');
+      router.push('/login');
+      return;
+    }
+    setOpen(true);
+  };
 
   return (
     <div className="flex flex-col justify-between p-7 bg-white rounded-2xl w-full max-w-[100%] h-auto min-h-[10rem] mt-[1rem]">
@@ -14,13 +29,13 @@ const ReservationComponent = ({ index }) => {
         </div>
         <button
           className="bg-[#3250F5] text-lg text-white rounded-3xl p-2 w-[15%]"
-          onClick={() => setOpen(true)}
+          onClick={handleOpenModal}
         >
           예약
         </button>
         <Modal isOpen={open} onClose={() => setOpen(false)} text="예약하기">
           <div className="p-4 flex flex-col h-full">
-            <div className="font-semibold text-2xl">스터디룸 1</div>
+            <div className="font-semibold text-2xl">스터디룸 {index}</div>
             <div className="flex justify-center items-center">8월 1일</div>
             <div className="flex flex-nowrap justify-between mt-4 mb-4 ">
               {Array.from({ length: 24 }, (_, index) => (

--- a/src/components/common/ReservationComponent.jsx
+++ b/src/components/common/ReservationComponent.jsx
@@ -11,6 +11,15 @@ const ReservationComponent = ({ index }) => {
   const router = useRouter();
   const { accessToken } = useTokenStore();
 
+  const currentHour = new Date().getHours();
+  const reservedHours = [13, 14, 15]; // 예: 이미 예약된 시간대 (13시~15시)
+
+  const getStatus = (hour) => {
+    if (reservedHours.includes(hour)) return 'reserved';
+    if (hour < currentHour) return 'past';
+    return 'available';
+  };
+
   const handleOpenModal = () => {
     if (!accessToken) {
       alert('로그인이 필요합니다.');
@@ -37,9 +46,9 @@ const ReservationComponent = ({ index }) => {
           <div className="p-4 flex flex-col h-full">
             <div className="font-semibold text-2xl">스터디룸 {index}</div>
             <div className="flex justify-center items-center">8월 1일</div>
-            <div className="flex flex-nowrap justify-between mt-4 mb-4 ">
-              {Array.from({ length: 24 }, (_, index) => (
-                <TimeComponent key={index} />
+            <div className="flex flex-nowrap justify-between mt-4 mb-4">
+              {Array.from({ length: 24 }, (_, i) => (
+                <TimeComponent key={i} status={getStatus(i)} />
               ))}
             </div>
             <div className="flex-grow">
@@ -61,11 +70,14 @@ const ReservationComponent = ({ index }) => {
           </div>
         </Modal>
       </div>
-      <div className="flex flex-nowrap justify-between ">
-        {Array.from({ length: 24 }, (_, index) => (
-          <TimeComponent key={index} />
+
+      {/* 하단의 타임라인 */}
+      <div className="flex flex-nowrap justify-between">
+        {Array.from({ length: 24 }, (_, i) => (
+          <TimeComponent key={i} status={getStatus(i)} />
         ))}
       </div>
+
       <div className="bg-black h-0.5 w-full bg-[#9999A3]"></div>
     </div>
   );

--- a/src/components/common/SecondBanner.jsx
+++ b/src/components/common/SecondBanner.jsx
@@ -1,4 +1,22 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import useTokenStore from '../../stores/useTokenStore';
+import React from 'react';
+
 const SecondBanner = () => {
+  const router = useRouter();
+  const { accessToken } = useTokenStore();
+
+  const handleReserveClick = () => {
+    if (!accessToken) {
+      alert('로그인이 필요합니다.');
+      router.push('/login');
+      return;
+    }
+    router.push('/');
+  };
+
   return (
     <div className="flex flex-col justify-between p-7 bg-[#788DFF] rounded-2xl w-full max-w-[95%] h-auto min-h-[10rem] mt-[1rem]">
       <div className="text-lg">이건 어떨까요?</div>
@@ -7,7 +25,10 @@ const SecondBanner = () => {
         <div className="text-sm text-white">
           자리를 미리 예약해보는건 어떨까요 ?
         </div>
-        <button className="bg-white text-[#788DFF] rounded px-4 py-2">
+        <button
+          onClick={handleReserveClick}
+          className="bg-white text-[#788DFF] rounded px-4 py-2"
+        >
           예약하기
         </button>
       </div>

--- a/src/components/common/TimeComponent.jsx
+++ b/src/components/common/TimeComponent.jsx
@@ -1,8 +1,14 @@
-const TimeComponent = () => {
+const TimeComponent = ({ status }) => {
+  let bgColor = '#788DFF';
+
+  if (status === 'reserved') bgColor = '#9999A3';
+  else if (status === 'past') bgColor = '#000000';
+
   return (
-    <>
-      <div className="w-[10px] h-[20px] bg-[#788DFF] "></div>
-    </>
+    <div
+      className="w-[18px] h-[20px] rounded-sm"
+      style={{ backgroundColor: bgColor }}
+    ></div>
   );
 };
 

--- a/src/components/common/TimeComponent.jsx
+++ b/src/components/common/TimeComponent.jsx
@@ -6,7 +6,7 @@ const TimeComponent = ({ status }) => {
 
   return (
     <div
-      className="w-[18px] h-[20px] rounded-sm"
+      className="w-[13px] h-[20px] rounded-sm"
       style={{ backgroundColor: bgColor }}
     ></div>
   );


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/mainpage-businesslogic

### 💡 작업동기
- 백엔드 api 연동 전 프론트 단에서 처리 가능한 비즈니스로직 구현 필요

### 🔑 주요 변경사항 
1. 홈 화면에서 accessToken 유무에 따라 로그인 전/후 배너 조건부 렌더링 추가
2. useTokenStore로 로그인 여부(accessToken) 확인 후 비로그인 상태면 alert 띄운 뒤 /login으로 이동 기능 추가
3. 시간대별 '예약 불가 / 지나간 시간 / 예약 가능' 상태에 따라 TimeComponent 색상 분기 처리 (`reservedHours` 배열을 활용한 임시 하드코딩 상태이며, 추후 예약 api 연동 예정) 기능 추가
4. person 아이콘 클릭 시 마이페이지 이동 기능 추가

### 🏞 스크린샷


### 관련 이슈 
- #1 