### PR TITLE
✨ [Feat] 예약 상세 모달 비즈니스 로직 구현

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -48,7 +48,7 @@ export default function Home() {
       <div className="flex justify-center w-full flex-grow">
         <ReservationSection className="w-full" />
       </div>
-      <div className="mt-[1px] w-full sticky fixed bg-white bottom-0 left-0 right-0 ">
+      <div className="mt-[1px] w-full sticky fixed bg-white bottom-0 left-0 right-0">
         <FooterNav />
       </div>
     </>

--- a/src/components/common/Modal.jsx
+++ b/src/components/common/Modal.jsx
@@ -5,7 +5,7 @@ const Modal = ({ isOpen, onClose, children, text, color }) => {
 
   return (
     <div
-      className="fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 flex justify-center items-center"
+      className="fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 flex justify-center items-center inset-0 z-[9999]"
       onClick={onClose}
     >
       <div

--- a/src/components/common/ReservationComponent.jsx
+++ b/src/components/common/ReservationComponent.jsx
@@ -8,11 +8,12 @@ import useTokenStore from '../../stores/useTokenStore';
 
 const ReservationComponent = ({ index }) => {
   const [open, setOpen] = useState(false);
+  const [startTime, setStartTime] = useState(null);
   const router = useRouter();
   const { accessToken } = useTokenStore();
 
   const currentHour = new Date().getHours();
-  const reservedHours = [13, 14, 15]; // 예: 이미 예약된 시간대 (13시~15시)
+  const reservedHours = [13, 14, 15];
 
   const getStatus = (hour) => {
     if (reservedHours.includes(hour)) return 'reserved';
@@ -27,6 +28,24 @@ const ReservationComponent = ({ index }) => {
       return;
     }
     setOpen(true);
+  };
+
+  const getStartTimeOptions = () => {
+    const options = [];
+    for (let i = currentHour; i < 24; i++) {
+      options.push(i);
+    }
+    return options;
+  };
+
+  const getEndTimeOptions = () => {
+    if (startTime === null) return [];
+    const options = [];
+    for (let i = 1; i <= 2; i++) {
+      const endHour = startTime + i;
+      options.push(endHour);
+    }
+    return options;
   };
 
   return (
@@ -46,32 +65,51 @@ const ReservationComponent = ({ index }) => {
           <div className="p-4 flex flex-col h-full">
             <div className="font-semibold text-2xl">스터디룸 {index}</div>
             <div className="flex justify-center items-center">8월 1일</div>
+
             <div className="flex flex-nowrap justify-between mt-4 mb-4">
               {Array.from({ length: 24 }, (_, i) => (
                 <TimeComponent key={i} status={getStatus(i)} />
               ))}
             </div>
-            <div className="flex-grow">
+
+            <div className="flex-grow mb-3">
               <div>예약 시간</div>
-              <select className="border rounded-md p-2 focus:outline-none w-full">
-                <option value="">10:00</option>
-                <option value="">11:00</option>
-                <option value="">12:00</option>
+              <select
+                className="border rounded-md p-2 focus:outline-none w-full"
+                value={startTime ?? ''}
+                onChange={(e) => setStartTime(Number(e.target.value))}
+              >
+                <option value="" disabled>
+                  시간 선택
+                </option>
+                {getStartTimeOptions().map((hour) => (
+                  <option key={hour} value={hour}>
+                    {hour}:00
+                  </option>
+                ))}
               </select>
             </div>
+
             <div className="flex-grow">
               <div>퇴실 시간</div>
-              <select className="border rounded-md p-2 focus:outline-none w-full">
-                <option value="">16:00</option>
-                <option value="">17:00</option>
-                <option value="">18:00</option>
+              <select
+                className="border rounded-md p-2 focus:outline-none w-full"
+                disabled={startTime === null}
+              >
+                <option value="" disabled selected>
+                  {startTime === null ? '예약 시간 선택 먼저' : '시간 선택'}
+                </option>
+                {getEndTimeOptions().map((hour) => (
+                  <option key={hour} value={hour}>
+                    {hour % 24}:00
+                  </option>
+                ))}
               </select>
             </div>
           </div>
         </Modal>
       </div>
 
-      {/* 하단의 타임라인 */}
       <div className="flex flex-nowrap justify-between">
         {Array.from({ length: 24 }, (_, i) => (
           <TimeComponent key={i} status={getStatus(i)} />


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/reservation-modal-businesslogic

### 💡 작업개요
- 사용자가 스터디룸 예약 시 유효한 시간대만 선택할 수 있도록 UX를 개선할 필요가 있었음
- 특히, 23시 이후 예약 시에도 퇴실 시간을 익일 0시 또는 1시로 설정 가능하도록 해야 하며, 기존 로직은 23시 이후의 퇴실 시간 표시를 제대로 지원하지 않았음
- 기존 예약 모달을 띄우면 화면 전체를 덮는 흐릿한 오버레이(backdrop)가 적용되었지만, 고정된 footer가 모달보다 위에 렌더링되어 UI가 깨지는 문제가 있었음
- 이는 footer 요소의 z-index가 모달보다 높게 설정되어 있었기 때문이며, 사용자 경험을 해치고 시각적 이질감을 유발

### 🔑 주요 변경사항 
1. 예약 시간 옵션은 현재 시각부터 23시까지 동적으로 생성되도록 수정
2. 퇴실 시간 옵션은 선택된 예약 시각 기준으로 +1, +2시간으로 표시되며, 23시인 경우에도 익일 0시, 1시로 자연스럽게 표시되도록 처리 (hour % 24)
3. 퇴실 시간이 존재하지 않는 조건에선 select 박스를 disabled 처리
4. 예약 시간 및 퇴실 시간 상태 관리를 위한 useState 로직 유지
5. Modal 컴포넌트에 z-[9999]와 fixed inset-0 설정 (전체 화면을 완전히 덮는 레이어 구조로 변경)

### 🏞 스크린샷


### 관련 이슈 
- #6  