### PR TITLE
[Feat] 예약 취소 api 연동 및 CancellationModal 버튼 연결 구현

### DIFF
--- a/src/components/common/AfterLoginBanner.jsx
+++ b/src/components/common/AfterLoginBanner.jsx
@@ -38,13 +38,38 @@ const AfterLoginBanner = () => {
     fetchLatestReservation();
   }, [userId, accessToken]);
 
+  const cancelReservation = async () => {
+    if (!latestReservation || !userId) return;
+
+    console.log('취소 요청 데이터', {
+      userId,
+      reservationId: latestReservation?.id,
+    });
+    console.log('예약 전체 객체', latestReservation);
+
+    try {
+      const res = await axiosInstance.post('/api/reservations/cancel', {
+        userId,
+        reservationId: latestReservation.id,
+      });
+
+      alert(res.data.message || '예약이 취소되었습니다.');
+      await fetchLatestReservation();
+      setOpen(false);
+    } catch (err) {
+      console.error('예약 취소 실패:', err);
+      alert(err.response?.data?.message || '예약 취소에 실패했습니다.');
+    }
+  };
+
   const handleModalClose = async () => {
     setOpen(false);
-    await fetchLatestReservation(); // 취소 후 정보 갱신
+    await fetchLatestReservation();
   };
 
   return (
     <div className="flex gap-[5px] w-full max-w-[95%]">
+      {/* 내 예약 정보 카드 */}
       <div className="flex flex-col bg-white rounded-2xl h-auto min-h-[15rem] w-1/2 p-10 gap-2.5">
         <div className="font-bold text-3xl">내가 예약한 방</div>
         <div className="text-2xl text-[#9999A2]">
@@ -64,7 +89,11 @@ const AfterLoginBanner = () => {
             취소
           </button>
 
-          <CancellationModal isOpen={open} onClose={handleModalClose}>
+          <CancellationModal
+            isOpen={open}
+            onClose={handleModalClose}
+            onConfirm={cancelReservation}
+          >
             <div className="p-4 flex flex-col h-full justify-center">
               <div className="font-semibold text-2xl">예약을 취소할까요?</div>
               {latestReservation && (

--- a/src/components/common/CancellationModal.jsx
+++ b/src/components/common/CancellationModal.jsx
@@ -1,4 +1,4 @@
-const CancellationModal = ({ isOpen, onClose, children }) => {
+const CancellationModal = ({ isOpen, onClose, onConfirm, children }) => {
   if (!isOpen) return null;
 
   return (
@@ -15,7 +15,9 @@ const CancellationModal = ({ isOpen, onClose, children }) => {
           <button className="text-gray-500 w-[50%]" onClick={onClose}>
             돌아가기
           </button>
-          <button className="text-[#C20000] w-[50%]">예약 취소</button>
+          <button className="text-[#C20000] w-[50%]" onClick={onConfirm}>
+            예약 취소
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/reservation-api

### 💡 작업개요
- 스터디룸 예약 내역을 취소할 수 있도록 예약 취소 API와의 연동 기능을 구현했습니다.
- 취소 요청은 모달 내 '예약 취소' 버튼 클릭 시 수행되며, 상태 관리와 최신 예약 갱신 로직도 함께 처리했습니다.

### 🔑 주요 변경사항 
1. 예약 취소 API 연동
- POST `/api/reservations/cancel` api 호출 로직 구현
- request body에 userId, reservationId 포함하여 전송

2.CancellationModal 기능 연결
- onConfirm prop 추가
- 버튼 클릭 시 onConfirm() 실행되도록 수정

3. AfterLoginBanner 내 상태 연동
- 모달 상태(open) 및 취소 완료 후 latestReservation 갱신 처리
- 예약 정보가 있는 경우에만 모달 활성화되도록 구현

4. 상태 관리 개선
- Zustand로 관리되는 userId, latestReservation 값을 활용해 api 호출

### 🏞 스크린샷


### 관련 이슈 
- #23 