### PR TITLE
Feat: 예약 시간 UI 개선 - 현재 시각 이후 시간만 표시 및 TimeComponent 좌측 정렬 적용

### DIFF
--- a/src/components/common/ReservationComponent.jsx
+++ b/src/components/common/ReservationComponent.jsx
@@ -84,41 +84,28 @@ const ReservationComponent = ({ index, roomId }) => {
       });
 
       alert(res.data.message || '예약이 완료되었습니다.');
-
       await fetchLatestReservation();
 
       setOpen(false);
       setStartTime(null);
       setEndTime(null);
     } catch (err) {
+      console.error('예약 실패:', err.response?.data || err.message);
       alert(err.response?.data?.message || '예약에 실패했습니다.');
     }
   };
 
   const renderTimeBlocks = () => {
-    const hours = Array.from(
-      { length: 24 - currentHour },
-      (_, i) => currentHour + i,
-    );
-    return (
-      <div className="flex flex-col items-start gap-1 mt-2">
-        <div className="flex gap-[4px]">
-          {hours.map((hour) => (
-            <span
-              key={`label-${hour}`}
-              className="text-[10px] w-[20px] text-center text-[#333]"
-            >
-              {hour}
-            </span>
-          ))}
-        </div>
-        <div className="flex gap-[4px]">
-          {hours.map((hour) => (
-            <TimeComponent key={hour} status={getStatus(hour)} />
-          ))}
-        </div>
-      </div>
-    );
+    const blocks = [];
+    for (let hour = currentHour; hour < 24; hour++) {
+      blocks.push(
+        <div key={hour} className="flex flex-col items-center w-[30px]">
+          <span className="text-xs text-[#4b4b4b]">{hour}</span>
+          <TimeComponent status={getStatus(hour)} />
+        </div>,
+      );
+    }
+    return blocks;
   };
 
   return (
@@ -143,13 +130,15 @@ const ReservationComponent = ({ index, roomId }) => {
         >
           <div className="p-4 flex flex-col h-full">
             <div className="font-semibold text-2xl">스터디룸 {index}</div>
-            <div className="flex justify-center items-center mb-4">
+            <div className="flex justify-center items-center">
               예약 날짜 자동 설정
             </div>
 
-            {renderTimeBlocks()}
+            <div className="flex overflow-x-auto gap-[2px] mt-4 mb-4">
+              {renderTimeBlocks()}
+            </div>
 
-            <div className="flex-grow mt-4 mb-3">
+            <div className="flex-grow mb-3">
               <div>예약 시간</div>
               <select
                 className="border rounded-md p-2 focus:outline-none w-full"
@@ -189,9 +178,11 @@ const ReservationComponent = ({ index, roomId }) => {
         </Modal>
       </div>
 
-      {renderTimeBlocks()}
+      <div className="flex overflow-x-auto gap-[2px] mt-4">
+        {renderTimeBlocks()}
+      </div>
 
-      <div className="bg-black h-0.5 w-full bg-[#9999A3] mt-2"></div>
+      <div className="bg-black h-0.5 w-full bg-[#9999A3] mt-3"></div>
     </div>
   );
 };

--- a/src/components/common/ReservationComponent.jsx
+++ b/src/components/common/ReservationComponent.jsx
@@ -75,15 +75,6 @@ const ReservationComponent = ({ index, roomId }) => {
       return;
     }
 
-    console.log('예약 전송 데이터 확인');
-    console.log('userId:', userId);
-    console.log('roomId:', roomId);
-    console.log(
-      '예약 시작/종료:',
-      reservationStart.toISOString(),
-      reservationEnd.toISOString(),
-    );
-
     try {
       const res = await axiosInstance.post('/api/reservations', {
         userId,
@@ -92,19 +83,42 @@ const ReservationComponent = ({ index, roomId }) => {
         reservationEndTime: reservationEnd.toISOString(),
       });
 
-      console.log('예약 응답 전체:', res.data);
       alert(res.data.message || '예약이 완료되었습니다.');
 
-      // 상태 직접 설정하지 않고 서버에서 다시 받아옴
       await fetchLatestReservation();
 
       setOpen(false);
       setStartTime(null);
       setEndTime(null);
     } catch (err) {
-      console.error('예약 실패:', err.response?.data || err.message);
       alert(err.response?.data?.message || '예약에 실패했습니다.');
     }
+  };
+
+  const renderTimeBlocks = () => {
+    const hours = Array.from(
+      { length: 24 - currentHour },
+      (_, i) => currentHour + i,
+    );
+    return (
+      <div className="flex flex-col items-start gap-1 mt-2">
+        <div className="flex gap-[4px]">
+          {hours.map((hour) => (
+            <span
+              key={`label-${hour}`}
+              className="text-[10px] w-[20px] text-center text-[#333]"
+            >
+              {hour}
+            </span>
+          ))}
+        </div>
+        <div className="flex gap-[4px]">
+          {hours.map((hour) => (
+            <TimeComponent key={hour} status={getStatus(hour)} />
+          ))}
+        </div>
+      </div>
+    );
   };
 
   return (
@@ -129,17 +143,13 @@ const ReservationComponent = ({ index, roomId }) => {
         >
           <div className="p-4 flex flex-col h-full">
             <div className="font-semibold text-2xl">스터디룸 {index}</div>
-            <div className="flex justify-center items-center">
+            <div className="flex justify-center items-center mb-4">
               예약 날짜 자동 설정
             </div>
 
-            <div className="flex flex-nowrap justify-between mt-4 mb-4">
-              {Array.from({ length: 24 }, (_, i) => (
-                <TimeComponent key={i} status={getStatus(i)} />
-              ))}
-            </div>
+            {renderTimeBlocks()}
 
-            <div className="flex-grow mb-3">
+            <div className="flex-grow mt-4 mb-3">
               <div>예약 시간</div>
               <select
                 className="border rounded-md p-2 focus:outline-none w-full"
@@ -179,13 +189,9 @@ const ReservationComponent = ({ index, roomId }) => {
         </Modal>
       </div>
 
-      <div className="flex flex-nowrap justify-between">
-        {Array.from({ length: 24 }, (_, i) => (
-          <TimeComponent key={i} status={getStatus(i)} />
-        ))}
-      </div>
+      {renderTimeBlocks()}
 
-      <div className="bg-black h-0.5 w-full bg-[#9999A3]"></div>
+      <div className="bg-black h-0.5 w-full bg-[#9999A3] mt-2"></div>
     </div>
   );
 };


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/reservation-ui-time-filter

### 💡 작업개요
1. 작업 배경
- 기존 예약 페이지에서는 0시부터 23시까지 모든 시간의 TimeComponent가 고정적으로 표시되어, 실제로 사용자가 예약할 수 없는 과거 시간까지 노출 -> 이는 사용자 경험(UX) 측면에서 비효율적
- 시간 블록(TimeComponent)이 전체 공간을 균등 분할하여 정렬됨으로써 좌측에 블록이 몰리지 않아 직관성이 떨어지는 문제 존재

2. 작업 목적
- 사용자가 현재 시각 이후의 예약 가능 시간만 빠르게 인지하고 선택할 수 있도록 UI를 개선
- 시간 블록(TimeComponent)이 좌측에 붙어서 정렬되도록 하여 모바일 환경에서도 시인성 높임
- 기존 예약 버튼, 예약 시간 선택 드롭다운 등 핵심 기능에는 전혀 영향을 주지 않고 UI만 개선

### 🔑 주요 변경사항 
1. 현재 시각 이후만 TimeComponent로 표시
   - `Array.from({ length: 24 - currentHour }, (_, i) => currentHour + i)` 패턴 적용
   - 모달 내부와 외부 UI에서 동일하게 적용

2. TimeComponent 위에 시간(숫자) 출력 추가
   - 21, 22, 23 등 시간 라벨을 블록 위에 출력하여 사용자의 이해를 돕도록 개선

3. TimeComponent 좌측 정렬
   - `flex flex-col items-start` 구조로 라벨 + 블록을 좌측 정렬
   - `gap-[4px]`와 `w-[20px]` 등 정사각형 박스로 배치 유지

4. 기존 레이아웃 유지
   - 예약 버튼, 스터디룸 타이틀, 인원 텍스트 등 기존 컴포넌트 및 스타일에는 영향 없음

### 🏞 스크린샷
<img width="334" height="718" alt="image" src="https://github.com/user-attachments/assets/78a3b1a1-304e-4b96-8a61-9ac225510388" />


### 관련 이슈 
- #23 