### PR TITLE
[Fix] 예약 시간대(KST) 처리 로직 수정 및 과거 시간 오류 해결

### DIFF
--- a/src/components/common/ReservationComponent.jsx
+++ b/src/components/common/ReservationComponent.jsx
@@ -8,6 +8,11 @@ import useTokenStore from '../../stores/useTokenStore';
 import useReservationStore from '../../stores/useReservationStore';
 import axiosInstance from '../../libs/api/instance';
 
+const toKSTISOString = (date) => {
+  const offset = date.getTimezoneOffset() * 60000;
+  return new Date(date.getTime() - offset).toISOString().slice(0, 19);
+};
+
 const ReservationComponent = ({ index, roomId }) => {
   const [open, setOpen] = useState(false);
   const [startTime, setStartTime] = useState(null);
@@ -56,7 +61,6 @@ const ReservationComponent = ({ index, roomId }) => {
     }
 
     const now = new Date();
-
     const reservationStart = new Date(now);
     if (startTime <= now.getHours()) {
       reservationStart.setDate(reservationStart.getDate() + 1);
@@ -79,8 +83,8 @@ const ReservationComponent = ({ index, roomId }) => {
       const res = await axiosInstance.post('/api/reservations', {
         userId,
         roomId,
-        reservationStartTime: reservationStart.toISOString(),
-        reservationEndTime: reservationEnd.toISOString(),
+        reservationStartTime: toKSTISOString(reservationStart),
+        reservationEndTime: toKSTISOString(reservationEnd),
       });
 
       alert(res.data.message || '예약이 완료되었습니다.');


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/reservation-timezone-bug

### 💡 작업개요
- 예약 기능에서 한국 시간 기준으로는 미래 시간대를 선택했음에도 불구하고, "과거 시간으로 예약할 수 없습니다"라는 알림이 잘못 표시되는 문제가 발생
- `Date.prototype.toISOString()` 메서드가 UTC 기준 문자열을 반환하기 때문이며, 백엔드에서 KST로 시간 처리를 하고 있어 불일치가 발생한 것이 원인

### 🔑 주요 변경사항 
#### 1. `toKSTISOString()` 함수 추가
- JavaScript의 `Date` 객체를 UTC 기준이 아닌 한국 표준시(KST) ISO 문자열로 변환하는 유틸 함수 구현

#### 2. 예약 요청 시 적용
 - 기존 `reservationStartTime.toISOString()` → `toKSTISOString(reservationStartTime)`으로 변경

#### 3. 시간 유효성 검증 개선
- `startTime`, `endTime` 조건 검사 시, 시간대 밀림 없이 정확한 비교가 가능하도록 보정

#### 4. 백엔드와 시간 일관성 확보
- 백엔드가 이미 `KST`로 설정된 환경을 기준으로 예약 검증을 수행하기 때문에, 프론트에서도 동일하게 맞춤

### 🏞 스크린샷

### 관련 이슈 
- #47