### PR TITLE
🐛 [Fix] reservedHours 하드코딩 제거 및 예약 성공 시 TimeComponent 상태 반영 

### DIFF
--- a/src/components/common/ReservationComponent.jsx
+++ b/src/components/common/ReservationComponent.jsx
@@ -8,6 +8,7 @@ import useTokenStore from '../../stores/useTokenStore';
 import useReservationStore from '../../stores/useReservationStore';
 import axiosInstance from '../../libs/api/instance';
 
+// ISO 문자열을 KST 기준으로 변환하는 함수
 const toKSTISOString = (date) => {
   const offset = date.getTimezoneOffset() * 60000;
   return new Date(date.getTime() - offset).toISOString().slice(0, 19);
@@ -17,6 +18,7 @@ const ReservationComponent = ({ index, roomId }) => {
   const [open, setOpen] = useState(false);
   const [startTime, setStartTime] = useState(null);
   const [endTime, setEndTime] = useState(null);
+  const [reservedHours, setReservedHours] = useState([]);
 
   const router = useRouter();
   const { userId, accessToken } = useTokenStore();
@@ -24,7 +26,6 @@ const ReservationComponent = ({ index, roomId }) => {
 
   const now = new Date();
   const currentHour = now.getHours();
-  const reservedHours = [13, 14, 15]; // 테스트용 예약 시간
 
   const getStatus = (hour) => {
     if (reservedHours.includes(hour)) return 'reserved';
@@ -89,6 +90,11 @@ const ReservationComponent = ({ index, roomId }) => {
 
       alert(res.data.message || '예약이 완료되었습니다.');
       await fetchLatestReservation();
+
+      // 예약 시간 반영
+      const newReserved = [startTime];
+      if (duration === 2) newReserved.push(startTime + 1);
+      setReservedHours((prev) => [...prev, ...newReserved]);
 
       setOpen(false);
       setStartTime(null);


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/reservation-status-sync

### 💡 작업개요
- 기존 예약 UI에서는 예약 시간(`reservedHours`)이 하드코딩된 `[13, 14, 15]`로 고정되어 있어 예약 생성 후 UI가 즉시 반영되지 않는 문제 존재
- 이 문제를 해결하고 실제 예약 시간 기반으로 상태를 동기화하기 위해 다음과 같은 개선 적용

### 🔑 주요 변경사항 
#### 1. `reservedHours` 상태 관리 개선
   - 기존의 고정값(`const reservedHours = [...]`)을 제거하고, `useState`를 활용해 동적으로 예약 시간 상태를 관리
   - 예약 생성 후 UI 업데이트를 위해 상태 기반 렌더링이 가능하도록 변경

#### 2. 예약 성공 시 시간 블록 반영
   - 예약이 성공적으로 완료되면 사용자가 선택한 `startTime` 및 예약 길이에 따라 `startTime + 1`을 `reservedHours` 배열에 즉시 추가
   - 예약 시간이 1시간 또는 2시간인 조건에 따라 유동적으로 예약 블록이 추가되도록 처리

#### 3. 초기 하드코딩된 예약 시간 제거
   - 기존 `useEffect`에서 예약 시간 배열 `[13, 14, 15]`를 강제로 설정하던 테스트용 코드를 제거
   - 실제로 예약이 발생했을 때만 예약 상태가 UI에 반영되도록 구조 변경

### 🏞 스크린샷

### 관련 이슈 
- #42 