### PR TITLE
✨ Feat: 예약 UI 개선(10분 단위 시각화 및 시간 정렬 개선)

### DIFF
--- a/src/components/common/ReservationComponent.jsx
+++ b/src/components/common/ReservationComponent.jsx
@@ -106,20 +106,25 @@ const ReservationComponent = ({ index, roomId }) => {
   const renderLine = (slots) => {
     return (
       <div className="w-full overflow-x-auto">
-        <div className="flex flex-row min-w-[720px] sm:min-w-0">
+        <div className="flex flex-row min-w-[720px] sm:min-w-0 gap-[1px]">
           {slots.map((time, idx) => {
             const hour = time.getHours();
-            const minute = time.getMinutes();
+            const isFirstOfHour = time.getMinutes() === 0;
             const timeStr = time.toISOString();
-            const isHourStart = minute === 0;
 
             return (
               <div
                 key={timeStr}
-                className={`flex flex-col items-center ${isHourStart ? 'mx-[2px]' : 'mx-[0.5px]'}`}
+                className="flex flex-col items-center justify-start"
               >
-                <span className="text-[10px] text-[#4b4b4b] mb-[2px]">
-                  {isHourStart ? hour : '\u00A0'}
+                <span
+                  className="text-[10px] text-[#4b4b4b]"
+                  style={{
+                    visibility: isFirstOfHour ? 'visible' : 'hidden',
+                    height: '16px',
+                  }}
+                >
+                  {hour}
                 </span>
                 <TimeComponent status={getStatus(timeStr)} />
               </div>

--- a/src/components/common/ReservationComponent.jsx
+++ b/src/components/common/ReservationComponent.jsx
@@ -106,8 +106,8 @@ const ReservationComponent = ({ index, roomId }) => {
   const renderLine = (slots) => {
     return (
       <div className="w-full overflow-x-auto">
-        <div className="flex flex-row min-w-[720px] sm:min-w-0 gap-[1px]">
-          {slots.map((time, idx) => {
+        <div className="flex flex-row min-w-[720px] sm:min-w-0">
+          {slots.map((time) => {
             const hour = time.getHours();
             const isFirstOfHour = time.getMinutes() === 0;
             const timeStr = time.toISOString();
@@ -116,12 +116,16 @@ const ReservationComponent = ({ index, roomId }) => {
               <div
                 key={timeStr}
                 className="flex flex-col items-center justify-start"
+                style={{ width: '10px' }}
               >
                 <span
-                  className="text-[10px] text-[#4b4b4b]"
+                  className="text-[10px] text-[#4b4b4b] leading-none"
                   style={{
                     visibility: isFirstOfHour ? 'visible' : 'hidden',
                     height: '16px',
+                    width: '16px',
+                    display: 'inline-block',
+                    textAlign: 'center',
                   }}
                 >
                   {hour}

--- a/src/components/common/ReservationComponent.jsx
+++ b/src/components/common/ReservationComponent.jsx
@@ -103,46 +103,52 @@ const ReservationComponent = ({ index, roomId }) => {
     }
   };
 
+  const renderLine = (slots) => {
+    return (
+      <div className="w-full overflow-x-auto">
+        <div className="flex flex-row min-w-[720px] sm:min-w-0">
+          {slots.map((time, idx) => {
+            const hour = time.getHours();
+            const minute = time.getMinutes();
+            const timeStr = time.toISOString();
+            const isHourStart = minute === 0;
+
+            return (
+              <div
+                key={timeStr}
+                className={`flex flex-col items-center ${isHourStart ? 'mx-[2px]' : 'mx-[0.5px]'}`}
+              >
+                <span className="text-[10px] text-[#4b4b4b] mb-[2px]">
+                  {isHourStart ? hour : '\u00A0'}
+                </span>
+                <TimeComponent status={getStatus(timeStr)} />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  };
+
   const renderTimeBlocks = () => {
     const timeSlots = getTimeSlots();
     const morningSlots = timeSlots.filter((time) => time.getHours() < 12);
     const afternoonSlots = timeSlots.filter((time) => time.getHours() >= 12);
 
-    const renderLine = (slots) => {
-      return (
-        <div className="w-full overflow-x-auto">
-          <div className="flex flex-row min-w-[720px] sm:min-w-0">
-            {slots.map((time) => {
-              const hour = time.getHours();
-              const minute = time.getMinutes();
-              const timeStr = time.toISOString();
-              const isHourStart = minute === 0;
-
-              return (
-                <div
-                  key={timeStr}
-                  className="flex flex-col items-center w-[6px]"
-                >
-                  {isHourStart ? (
-                    <span className="text-[10px] text-[#4b4b4b] mb-[2px]">
-                      {hour}
-                    </span>
-                  ) : (
-                    <span className="text-[10px] mb-[2px]">&nbsp;</span>
-                  )}
-                  <TimeComponent status={getStatus(timeStr)} />
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      );
-    };
-
     return (
-      <div className="flex flex-col w-full">
-        {morningSlots.length > 0 && renderLine(morningSlots)}
-        {afternoonSlots.length > 0 && renderLine(afternoonSlots)}
+      <div className="flex flex-col w-full gap-2">
+        {morningSlots.length > 0 && (
+          <div>
+            <div className="text-xs font-semibold mb-1">오전</div>
+            {renderLine(morningSlots)}
+          </div>
+        )}
+        {afternoonSlots.length > 0 && (
+          <div>
+            <div className="text-xs font-semibold mb-1">오후</div>
+            {renderLine(afternoonSlots)}
+          </div>
+        )}
       </div>
     );
   };

--- a/src/components/common/TimeComponent.jsx
+++ b/src/components/common/TimeComponent.jsx
@@ -13,7 +13,7 @@ const TimeComponent = ({ status }) => {
 
   return (
     <div
-      className="w-[4px] h-[10px] sm:w-[6px] sm:h-[14px] transition-colors duration-200"
+      className="w-[8px] h-[14px] transition-colors duration-200"
       style={{ backgroundColor: getColor() }}
     />
   );

--- a/src/components/common/TimeComponent.jsx
+++ b/src/components/common/TimeComponent.jsx
@@ -1,14 +1,25 @@
 const TimeComponent = ({ status }) => {
-  let bgColor = '#788DFF';
-
-  if (status === 'reserved') bgColor = '#9999A3';
-  else if (status === 'past') bgColor = '#000000';
+  const getColor = () => {
+    switch (status) {
+      case 'reserved':
+        return '#9999A3';
+      case 'past':
+        return '#000000';
+      case 'available':
+      default:
+        return '#788DFF';
+    }
+  };
 
   return (
     <div
-      className="w-[13px] h-[20px] rounded-sm"
-      style={{ backgroundColor: bgColor }}
-    ></div>
+      className="
+        w-[4px] h-[10px] mx-[0.5px]
+        sm:w-[6px] sm:h-[14px]
+        transition-colors duration-200
+      "
+      style={{ backgroundColor: getColor() }}
+    />
   );
 };
 

--- a/src/components/common/TimeComponent.jsx
+++ b/src/components/common/TimeComponent.jsx
@@ -13,11 +13,7 @@ const TimeComponent = ({ status }) => {
 
   return (
     <div
-      className="
-        w-[4px] h-[10px] mx-[0.5px]
-        sm:w-[6px] sm:h-[14px]
-        transition-colors duration-200
-      "
+      className="w-[4px] h-[10px] sm:w-[6px] sm:h-[14px] transition-colors duration-200"
       style={{ backgroundColor: getColor() }}
     />
   );


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/reservation-10min-interval

### 💡 작업개요
- 기존 예약 UI는 시간대 숫자(`시간 라벨`)와 실제 블록(`TimeComponent`) 간 정렬 불일치, 시간 간격 불균형, 모바일 비대응 등의 문제로 사용성이 떨어짐
- 1시간 단위 기준으로 시간 정보가 표시되어 10분 단위 예약의 시각적 직관성이 부족

### 🔑 주요 변경사항 
1. `TimeComponent.jsx` 리팩터링
- 상태별 색상 (`reserved`, `past`, `available`) 동적 처리
- 반응형 대응: 모바일에서는 `4px`, 데스크탑에서는 `6px` 너비 적용
- `transition-colors` 추가로 상태 전환 시 부드러운 변화 구현

2. `ReservationComponent.jsx` 구조적 개선
- 시간 블록 렌더링 정렬 구조 개선: 시간 숫자 (`0~23`)가 정확히 해당 `TimeComponent`의 시작 위치에 정렬되도록 `flex-col items-center` 구조로 수정
- 자릿수에 따른 숫자 간격 차이 해결: `width`를 고정하고 `textAlign: center` 적용으로 모든 숫자 간격 통일
- 가로 스크롤 대응: `overflow-x-auto` + `min-w-[1440px]` 적용을 통해 모든 디바이스에서 자연스러운 좌우 스크롤 구현
- 10분 단위 시간 슬롯 생성: `getTimeSlots()` 함수로 하루를 10분 단위로 분할 (`00:00 ~ 23:59`)
- 상태 계산 로직 개선: `"display-only"` 구간(23:59)은 시각화 제외, `reservedTimes` 배열 기반으로 `reserved`, `past`, `available` 상태 계산
- 모달 내 시각화 일치: 예약 모달 안에서도 동일한 UI 컴포넌트를 사용하여 UI 일관성 유지

3. 시간 간격 시각화 개선
- 모든 10분 단위 블록 간의 간격을 동일하게 유지 (`mx-[0.5px]` 등 Tailwind 기준 적용)
- 한자리 숫자(0~9)와 두자리 숫자(10~23) 간의 폭 차이를 제거하여 간격 불균형 문제 해결
- 데스크탑 환경에서도 정확히 정렬된 모습으로 시각적 완성도 향상

### 🏞 스크린샷
<img width="605" height="814" alt="image" src="https://github.com/user-attachments/assets/5ab5c9cf-4813-4cba-bdf3-9fb698cc8808" />
<img width="336" height="721" alt="image" src="https://github.com/user-attachments/assets/1bb16115-f714-40bf-80f8-1e45edcee1db" />

### 🔗 관련 이슈 
- #30 