### PR TITLE
🐛 [Fix] 예약 시간 표시 오류 수정 (KST 배열 Date 처리 수정)

### DIFF
--- a/src/components/common/AfterLoginBanner.jsx
+++ b/src/components/common/AfterLoginBanner.jsx
@@ -11,20 +11,22 @@ const AfterLoginBanner = () => {
   const { userId, accessToken } = useTokenStore();
   const { latestReservation, setLatestReservation } = useReservationStore();
 
-  const parseToDate = (input) => {
+  const toKSTDate = (input) => {
     if (!input) return null;
 
     if (Array.isArray(input)) {
       const [year, month, day, hour = 0, minute = 0] = input;
-      return new Date(Date.UTC(year, month - 1, day, hour, minute));
+      return new Date(year, month - 1, day, hour, minute);
     }
 
-    return new Date(input);
+    const date = new Date(input);
+    if (isNaN(date.getTime())) return null;
+    return date;
   };
 
   const formatTime = (input) => {
-    const date = parseToDate(input);
-    if (!date || isNaN(date.getTime())) return '--:--';
+    const date = toKSTDate(input);
+    if (!date) return '--:--';
     return date.toLocaleTimeString('ko-KR', {
       hour: '2-digit',
       minute: '2-digit',
@@ -32,10 +34,21 @@ const AfterLoginBanner = () => {
   };
 
   const formatDate = (input) => {
-    const date = parseToDate(input);
-    if (!date || isNaN(date.getTime())) return '날짜 없음';
-    return date.toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' });
+    const date = toKSTDate(input);
+    if (!date) return '날짜 없음';
+    return date.toLocaleDateString('ko-KR', {
+      month: 'long',
+      day: 'numeric',
+    });
   };
+
+  const getStartTime = () =>
+    latestReservation?.startTime ??
+    latestReservation?.reservationStartTime ??
+    null;
+
+  const getEndTime = () =>
+    latestReservation?.endTime ?? latestReservation?.reservationEndTime ?? null;
 
   const fetchLatestReservation = async () => {
     if (!userId || !accessToken) return;
@@ -53,6 +66,12 @@ const AfterLoginBanner = () => {
   useEffect(() => {
     fetchLatestReservation();
   }, [userId, accessToken]);
+
+  useEffect(() => {
+    if (latestReservation) {
+      console.log('📦 예약 데이터 확인:', latestReservation);
+    }
+  }, [latestReservation]);
 
   const cancelReservation = async () => {
     if (!latestReservation?.id || !userId) {
@@ -81,6 +100,7 @@ const AfterLoginBanner = () => {
 
   return (
     <div className="flex gap-[5px] w-full max-w-[95%]">
+      {/* 좌측 박스 */}
       <div className="flex flex-col bg-white rounded-2xl h-auto min-h-[15rem] w-1/2 p-10 gap-2.5">
         <div className="font-bold text-3xl">내가 예약한 방</div>
         <div className="text-2xl text-[#9999A2]">
@@ -88,11 +108,8 @@ const AfterLoginBanner = () => {
         </div>
         <div className="flex justify-between">
           <div className="text-xl">
-            {latestReservation
-              ? formatTime(
-                  latestReservation.startTime ||
-                    latestReservation.reservationStartTime,
-                )
+            {latestReservation && getStartTime()
+              ? formatTime(getStartTime())
               : '--:--'}
           </div>
           <button
@@ -118,22 +135,9 @@ const AfterLoginBanner = () => {
                   />
                   <div className="flex flex-col justify-center">
                     <div>{latestReservation.roomName}</div>
+                    <div>{formatDate(getStartTime())}</div>
                     <div>
-                      {formatDate(
-                        latestReservation.startTime ||
-                          latestReservation.reservationStartTime,
-                      )}
-                    </div>
-                    <div>
-                      {formatTime(
-                        latestReservation.startTime ||
-                          latestReservation.reservationStartTime,
-                      )}
-                      {' ~ '}
-                      {formatTime(
-                        latestReservation.endTime ||
-                          latestReservation.reservationEndTime,
-                      )}
+                      {formatTime(getStartTime())} ~ {formatTime(getEndTime())}
                     </div>
                   </div>
                 </div>
@@ -143,6 +147,7 @@ const AfterLoginBanner = () => {
         </div>
       </div>
 
+      {/* 우측 박스 */}
       <div className="flex bg-white rounded-2xl h-auto min-h-[15rem] w-1/2 p-10 flex-col justify-between">
         <div className="flex flex-col gap-2.5">
           <div className="text-xl">오늘의 혼잡도</div>

--- a/src/components/common/AfterLoginBanner.jsx
+++ b/src/components/common/AfterLoginBanner.jsx
@@ -67,12 +67,6 @@ const AfterLoginBanner = () => {
     fetchLatestReservation();
   }, [userId, accessToken]);
 
-  useEffect(() => {
-    if (latestReservation) {
-      console.log('📦 예약 데이터 확인:', latestReservation);
-    }
-  }, [latestReservation]);
-
   const cancelReservation = async () => {
     if (!latestReservation?.id || !userId) {
       alert('취소할 예약 정보가 없습니다.');


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/timezone-kst-display

### 💡 작업개요
- 예약 배너에 표시되는 시간이 실제 예약한 시간과 다르게 출력되는 문제 발생
- 백엔드에서 전달한 `startTime`, `endTime` 값이 KST 기준 배열([YYYY, MM, DD, HH, mm])*형태임에도 불구하고 기존 코드에서는 이를 UTC 기준으로 잘못 처리하여 9시간이 중복 보정된 것이 원인

### 🔑 주요 변경사항 
1. 시간 파싱 함수 수정 (`toKSTDate`)
   - 기존: `Date.UTC(...) + 9시간`으로 이중 보정된 Date 생성
   - 변경: 배열 데이터를 `new Date(year, month - 1, day, hour, minute)` 방식으로 처리하여 KST 기준 시간 정확히 반영

2. 시간/날짜 포맷 로직 유지
   - `toLocaleTimeString('ko-KR')` 및 `toLocaleDateString('ko-KR')` 사용
   - Date 객체 생성 방식만 변경하여 로직 전체 구조는 그대로 유지

### 🏞 스크린샷

### 🔗 관련 이슈 
- #53 