### PR TITLE
[Feat] 예약 상태 필터링 및 예약 관련 UI 개선

### DIFF
--- a/src/components/common/AfterLoginBanner.jsx
+++ b/src/components/common/AfterLoginBanner.jsx
@@ -13,12 +13,10 @@ const AfterLoginBanner = () => {
 
   const toKSTDate = (input) => {
     if (!input) return null;
-
     if (Array.isArray(input)) {
       const [year, month, day, hour = 0, minute = 0] = input;
       return new Date(year, month - 1, day, hour, minute);
     }
-
     const date = new Date(input);
     if (isNaN(date.getTime())) return null;
     return date;
@@ -36,10 +34,7 @@ const AfterLoginBanner = () => {
   const formatDate = (input) => {
     const date = toKSTDate(input);
     if (!date) return '날짜 없음';
-    return date.toLocaleDateString('ko-KR', {
-      month: 'long',
-      day: 'numeric',
-    });
+    return `${date.getMonth() + 1}월 ${date.getDate()}일`;
   };
 
   const getStartTime = () =>
@@ -94,16 +89,17 @@ const AfterLoginBanner = () => {
 
   return (
     <div className="flex gap-[5px] w-full max-w-[95%]">
-      {/* 좌측 박스 */}
       <div className="flex flex-col bg-white rounded-2xl h-auto min-h-[15rem] w-1/2 p-10 gap-2.5">
         <div className="font-bold text-3xl">내가 예약한 방</div>
         <div className="text-2xl text-[#9999A2]">
-          {latestReservation ? latestReservation.roomName : '예약 내역 없음'}
+          {latestReservation
+            ? `스터디룸 ${latestReservation.roomName}`
+            : '예약 내역 없음'}
         </div>
         <div className="flex justify-between">
           <div className="text-xl">
             {latestReservation && getStartTime()
-              ? formatTime(getStartTime())
+              ? `${formatDate(getStartTime())} ${formatTime(getStartTime())}`
               : '--:--'}
           </div>
           <button
@@ -121,14 +117,14 @@ const AfterLoginBanner = () => {
             <div className="p-4 flex flex-col h-full justify-center">
               <div className="font-semibold text-2xl">예약을 취소할까요?</div>
               {latestReservation && (
-                <div className="flex gap-[10px] bg-[#788DFF] bg-opacity-10 p-4 mt-10">
+                <div className="flex gap-[10px] bg-[#788DFF] bg-opacity-10 p-4 mt-10 rounded-xl">
                   <img
                     src="/static/icons/studyroom_image.png"
                     alt="studyroom"
-                    className="w-1/4 h-auto items-center"
+                    className="w-1/4 h-auto items-center rounded"
                   />
                   <div className="flex flex-col justify-center">
-                    <div>{latestReservation.roomName}</div>
+                    <div className="font-medium">{`스터디룸 ${latestReservation.roomName}`}</div>
                     <div>{formatDate(getStartTime())}</div>
                     <div>
                       {formatTime(getStartTime())} ~ {formatTime(getEndTime())}
@@ -141,7 +137,6 @@ const AfterLoginBanner = () => {
         </div>
       </div>
 
-      {/* 우측 박스 */}
       <div className="flex bg-white rounded-2xl h-auto min-h-[15rem] w-1/2 p-10 flex-col justify-between">
         <div className="flex flex-col gap-2.5">
           <div className="text-xl">오늘의 혼잡도</div>

--- a/src/components/common/AfterLoginBanner.jsx
+++ b/src/components/common/AfterLoginBanner.jsx
@@ -49,7 +49,6 @@ const AfterLoginBanner = () => {
     if (!userId || !accessToken) return;
     try {
       const res = await axiosInstance.get(`/api/reservations/user/${userId}`);
-
       const nowKST = new Date(new Date().getTime() + 9 * 60 * 60 * 1000);
 
       const activeReservations = res.data.reservations.filter((r) => {
@@ -86,7 +85,6 @@ const AfterLoginBanner = () => {
       alert(res.data.message || '예약이 취소되었습니다.');
       setLatestReservation(null);
       setOpen(false);
-
       fetchLatestReservation();
     } catch (err) {
       console.error('예약 취소 실패:', err);
@@ -94,28 +92,40 @@ const AfterLoginBanner = () => {
     }
   };
 
-  const handleModalClose = () => {
-    setOpen(false);
-  };
+  const handleModalClose = () => setOpen(false);
 
   return (
     <div className="flex gap-[5px] w-full max-w-[95%]">
-      <div className="flex flex-col bg-white rounded-2xl h-auto min-h-[15rem] w-1/2 p-10 gap-2.5">
-        <div className="font-bold text-3xl">내가 예약한 방</div>
-        <div className="text-2xl text-[#9999A2]">
+      <div className="flex bg-white rounded-2xl h-auto min-h-[15rem] w-1/2 p-6 flex-col justify-between">
+        <div className="flex flex-col gap-2.5">
+          <div className="text-sm md:text-xl">오늘의 혼잡도</div>
+          <div className="text-xl md:text-5xl text-[#788DFF] font-semibold">
+            여유로움
+          </div>
+        </div>
+        <img
+          src="/static/icons/maru_icon.png"
+          alt="maru"
+          className="w-1/2 h-3/4 self-end"
+        />
+      </div>
+
+      <div className="flex flex-col bg-white rounded-2xl h-auto min-h-[15rem] w-1/2 p-6 gap-2.5">
+        <div className="font-bold text-base md:text-3xl">내가 예약한 방</div>
+        <div className="text-sm md:text-2xl text-[#9999A2]">
           {latestReservation
             ? `스터디룸 ${latestReservation.roomName}`
             : '예약 내역 없음'}
         </div>
-        <div className="flex justify-between">
-          <div className="text-xl">
+        <div className="flex justify-between items-center">
+          <div className="text-sm md:text-xl">
             {latestReservation && getStartTime()
               ? `${formatDate(getStartTime())} ${formatTime(getStartTime())}`
               : '--:--'}
           </div>
           {latestReservation && (
             <button
-              className="text-xl text-[#788DFF]"
+              className="text-sm md:text-xl text-[#788DFF]"
               onClick={() => setOpen(true)}
             >
               취소
@@ -127,39 +137,28 @@ const AfterLoginBanner = () => {
             onClose={handleModalClose}
             onConfirm={cancelReservation}
           >
-            <div className="p-4 flex flex-col h-full justify-center">
-              <div className="font-semibold text-2xl">예약을 취소할까요?</div>
-              {latestReservation && (
-                <div className="flex gap-[10px] bg-[#788DFF] bg-opacity-10 p-4 mt-10 rounded-xl">
-                  <img
-                    src="/static/icons/studyroom_image.png"
-                    alt="studyroom"
-                    className="w-1/4 h-auto items-center rounded"
-                  />
-                  <div className="flex flex-col justify-center">
-                    <div className="font-medium">{`스터디룸 ${latestReservation.roomName}`}</div>
-                    <div>{formatDate(getStartTime())}</div>
-                    <div>
-                      {formatTime(getStartTime())} ~ {formatTime(getEndTime())}
-                    </div>
+            <div className="text-base md:text-lg font-semibold text-left mb-4">
+              예약을 취소할까요?
+            </div>
+
+            {latestReservation && (
+              <div className="flex items-center gap-4 bg-[#F5F7FF] p-4 rounded-lg">
+                <img
+                  src="/static/icons/studyroom_image.png"
+                  alt="studyroom"
+                  className="w-[80px] h-[80px] object-cover rounded-md"
+                />
+                <div className="flex flex-col text-sm md:text-lg">
+                  <div className="font-medium">{`스터디룸 ${latestReservation.roomName}`}</div>
+                  <div>{formatDate(getStartTime())}</div>
+                  <div>
+                    {formatTime(getStartTime())} ~ {formatTime(getEndTime())}
                   </div>
                 </div>
-              )}
-            </div>
+              </div>
+            )}
           </CancellationModal>
         </div>
-      </div>
-
-      <div className="flex bg-white rounded-2xl h-auto min-h-[15rem] w-1/2 p-10 flex-col justify-between">
-        <div className="flex flex-col gap-2.5">
-          <div className="text-xl">오늘의 혼잡도</div>
-          <div className="text-5xl text-[#788DFF] font-semibold">여유로움</div>
-        </div>
-        <img
-          src="/static/icons/maru_icon.png"
-          alt="maru"
-          className="w-1/2 h-3/4 self-end"
-        />
       </div>
     </div>
   );

--- a/src/components/common/CancellationModal.jsx
+++ b/src/components/common/CancellationModal.jsx
@@ -5,19 +5,32 @@ const CancellationModal = ({ isOpen, onClose, onConfirm, children }) => {
 
   return (
     <div
-      className="fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 flex justify-center items-center"
+      className="fixed top-0 left-0 w-full h-full 
+                 bg-black bg-opacity-50 
+                 flex justify-center items-center 
+                 z-[9999]"
       onClick={onClose}
     >
       <div
-        className="bg-white rounded-lg shadow-lg p-4 relative w-[90%] max-w-2xl h-[40%] flex flex-col"
+        className="bg-white rounded-[20px] w-[90%] max-w-[500px] p-6 sm:p-8 flex flex-col justify-between"
         onClick={(e) => e.stopPropagation()}
       >
-        {children}
-        <div className="flex justify-center justify-between p-2 cursor-pointer">
-          <button className="text-gray-500 w-[50%]" onClick={onClose}>
+        <div className="overflow-y-auto max-h-[70vh]">{children}</div>
+
+        <div className="flex w-full mt-6 rounded-xl overflow-hidden border border-[#3250F5]">
+          <button
+            onClick={onClose}
+            className="w-1/2 py-3 bg-white text-[#5C5C5C] text-sm font-medium rounded-none"
+          >
             돌아가기
           </button>
-          <button className="text-[#C20000] w-[50%]" onClick={onConfirm}>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              if (onConfirm) onConfirm();
+            }}
+            className="w-1/2 py-3 bg-[#7389FF] text-white text-sm font-semibold rounded-none"
+          >
             예약 취소
           </button>
         </div>


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/reservation-modal-ui-formatting

### 💡 작업개요
- 사용자의 예약 경험을 개선하기 위해 예약 상태 필터링 로직을 보완하고, AfterLoginBanner 및 예약 취소 모달 UI 정비
- 예약 정보가 더 명확히 전달되도록 날짜 및 시간 표시 포맷을 수정하고, 모바일 대응을 위한 반응형 스타일 개선을 수행
- 사용자의 직관적 조작을 위해 예약 취소 모달에 블러 처리와 레이아웃 정리를 적용


### 🔑 주요 변경사항 
1. 예약 상태 필터링 기능 개선
- `AfterLoginBanner`에서 `status`가 `"CANCELLED"`인 예약은 렌더링 대상에서 제외되도록 수정
- 현재 시각(KST) 이후의 예약만 필터링하도록 UTC → KST 시간 변환 로직 적용

2. AfterLoginBanner 레이아웃 개선
- 예약 정보에 날짜(월/일)와 시간(오전/오후)을 함께 표시하도록 포맷팅 함수(`formatDate`, `formatTime`) 분리 및 적용
- 텍스트 요소에 Tailwind 반응형 클래스(`text-base md:text-xl`)를 적용하여 모바일 환경에서 자동으로 크기 축소되도록 구현

3. 예약 취소 모달 UI 개선
- 취소 모달에 카드 형태의 예약 상세 정보 UI 추가: 방 이름, 날짜, 시간 정보 등 표시
- `모달 오버레이`에 블러 처리(`bg-black/50`) 적용하여 집중도 향상
- "돌아가기", "예약 취소" 버튼을 1:1 정렬 및 레이아웃 정비
- 클릭 이벤트 차단으로 모달 외 영역 클릭 시만 닫히도록 처리

### 🏞 스크린샷
<img width="332" height="718" alt="image" src="https://github.com/user-attachments/assets/cb9e56e3-2f15-4748-8f6a-37e03c65bdb9" />
<img width="605" height="814" alt="image" src="https://github.com/user-attachments/assets/9e4e3917-4b15-401f-8887-9abbe3e068e0" />


### 🔗 관련 이슈 
- #60 