### PR TITLE
[Fix] Zustand 상태 초기화 리팩터링 및 hydration mismatch 문제 해결

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -12,8 +12,17 @@ import useTokenStore from '../stores/useTokenStore';
 import { jwtDecode } from 'jwt-decode';
 
 export default function Home() {
-  const { accessToken, setUserId } = useTokenStore();
+  const { accessToken, setUserId, initializeFromStorage } = useTokenStore();
+
   const [userInfo, setUserInfo] = useState({ id: '', email: '' });
+  const [isMounted, setIsMounted] = useState(false); // hydration mismatch 방지
+
+  useEffect(() => {
+    setIsMounted(true); // CSR 이후에만 렌더링하게 함
+
+    // Zustand 상태를 클라이언트에서 초기화
+    initializeFromStorage();
+  }, []);
 
   useEffect(() => {
     if (accessToken) {
@@ -21,7 +30,6 @@ export default function Home() {
         const decoded = jwtDecode(accessToken);
         const { id, email } = decoded;
 
-        // 디코드된 userId 바로 저장
         setUserId(id);
         setUserInfo({ id, email });
 
@@ -35,11 +43,15 @@ export default function Home() {
     }
   }, [accessToken, setUserId]);
 
+  // 서버에서는 아무것도 렌더링하지 않도록 처리
+  if (!isMounted) return null;
+
   return (
     <>
       <div className="w-full">
         <Header />
       </div>
+
       <div className="flex justify-center w-full">
         {accessToken ? (
           <AfterLoginBanner className="w-full" />
@@ -47,12 +59,15 @@ export default function Home() {
           <Banner className="w-full" />
         )}
       </div>
+
       <div className="flex justify-center w-full">
         <SecondBanner className="w-full" />
       </div>
+
       <div className="flex justify-center w-full flex-grow">
         <ReservationSection className="w-full" />
       </div>
+
       <div className="mt-[1px] w-full sticky fixed bg-white bottom-0 left-0 right-0">
         <FooterNav />
       </div>

--- a/src/stores/useTokenStore.js
+++ b/src/stores/useTokenStore.js
@@ -1,18 +1,19 @@
 import { create } from 'zustand';
 
 const useTokenStore = create((set) => ({
-  accessToken:
-    typeof window !== 'undefined'
-      ? sessionStorage.getItem('accessToken') || ''
-      : '',
-  refreshToken:
-    typeof window !== 'undefined'
-      ? sessionStorage.getItem('refreshToken') || ''
-      : '',
-  userId:
-    typeof window !== 'undefined'
-      ? parseInt(sessionStorage.getItem('userId')) || null
-      : null,
+  accessToken: '',
+  refreshToken: '',
+  userId: null,
+
+  initializeFromStorage: () => {
+    if (typeof window !== 'undefined') {
+      const accessToken = sessionStorage.getItem('accessToken') || '';
+      const refreshToken = sessionStorage.getItem('refreshToken') || '';
+      const userId = parseInt(sessionStorage.getItem('userId')) || null;
+
+      set({ accessToken, refreshToken, userId });
+    }
+  },
 
   setAccessToken: (token) => {
     set({ accessToken: token });


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/hydration-mismatch

### 💡 작업개요
- Zustand 상태가 클라이언트 측에서만 존재하는 값(`sessionStorage`)에 의존하여 초기화될 경우, 서버 사이드 렌더링 시에는 해당 값이 비어 있는 상태로 렌더링되기 때문에 UI가 일치하지 않게됨

### 🔑 주요 변경사항 
### 1. Zustand 초기화 방식 개선
- `accessToken`, `refreshToken`, `userId` 상태의 초기화를 `create` 함수 내에서 직접 수행하던 기존 방식 제거
- 대신 `initializeFromStorage()` 메서드를 도입하여, 브라우저 환경(`window !== 'undefined'`)에서만 `sessionStorage`에서 값을 가져오도록 변경
- 이 메서드는 클라이언트 사이드에서만 호출되므로 SSR 시점에는 상태가 undefined 상태로 유지되어 hydration 오류 방지 가능

### 2. 클라이언트 렌더링 여부 확인 (`isMounted`)
- `Home.jsx`에서 `useEffect`를 통해 마운트 이후(`isMounted === true`)에만 본문을 렌더링하도록 처리
- 이렇게 하면 서버에서 아무것도 렌더링하지 않고, 클라이언트 렌더링 이후에만 토큰 기반 UI 구성

### 3. accessToken 디코딩 시점 조절
- `initializeFromStorage()` 실행 이후에만 토큰 디코딩이 가능하도록 순서 재배치
- `jwtDecode()` 호출도 클라이언트 사이드에서만 이루어지도록 안전성 강화

### 🏞 스크린샷

### 🔗 관련 이슈 
- #59 