### PR TITLE
[Feat] 관리자 예약 목록 조회 기능 구현 및 최신순 정렬 처리

### DIFF
--- a/src/app/admin/dashboard/page.jsx
+++ b/src/app/admin/dashboard/page.jsx
@@ -11,25 +11,28 @@ export default function AdminDashboard() {
     <div className="w-full min-h-screen bg-[#F5F5F5] px-10 py-8">
       <div className="flex justify-between items-center bg-white border p-4 rounded mb-6">
         <h1 className="text-lg font-semibold">
-          오늘의 할 일{' '}
-          <span className="ml-2 text-white text-xs px-2 py-1 rounded bg-[#788DFF]">
+          관리자 페이지 대시보드{' '}
+          {/* <span className="ml-2 text-white text-xs px-2 py-1 rounded bg-[#788DFF]">
             2
-          </span>
+          </span> */}
         </h1>
         <div className="flex gap-2">
-          <button className="bg-[#788DFF] text-white text-sm px-4 py-2 rounded">
-            현황 업데이트
+          <button
+            className="bg-[#788DFF] text-white text-sm px-4 py-2 rounded"
+            onClick={() => router.push('/')}
+          >
+            예약 서비스 화면으로 가기
           </button>
-          <button className="bg-[#888888] text-white text-sm px-4 py-2 rounded">
+          {/* <button className="bg-[#888888] text-white text-sm px-4 py-2 rounded">
             나가기
-          </button>
+          </button> */}
         </div>
       </div>
 
-      <div className="text-sm text-[#333] mb-6">
+      {/* <div className="text-sm text-[#333] mb-6">
         답변대기 건의 <span className="text-[#788DFF]">2</span> / 불쾌사용자
         신고 <span className="text-[#788DFF]">0</span>
-      </div>
+      </div> */}
 
       <div className="grid grid-cols-3 gap-6">
         {/* 예약 현황 */}

--- a/src/app/admin/dashboard/page.jsx
+++ b/src/app/admin/dashboard/page.jsx
@@ -38,10 +38,10 @@ export default function AdminDashboard() {
         {/* 예약 현황 */}
         <div className="col-span-2 bg-white p-4 rounded shadow">
           <div className="flex justify-between items-center mb-3">
-            <h2 className="font-semibold">예약 현황</h2>
+            <h2 className="font-semibold">날짜별 예약 현황</h2>
             <button
               className="text-sm text-[#788DFF]"
-              onClick={() => router.push('/admin/reservation-detail')}
+              onClick={() => router.push('/admin/reservations-by-date')}
             >
               더보기
             </button>

--- a/src/app/admin/layout.jsx
+++ b/src/app/admin/layout.jsx
@@ -18,7 +18,8 @@ export default function AdminLayout({ children }) {
                 대시보드
               </a>
               <a href="/admin/user-management">사용자 관리</a>
-              <a href="/admin/reservation-detail">예약</a>
+              <a href="/admin/reservations-by-date">날짜별 예약 현황</a>
+              <a href="/admin/reservation-detail">예약 목록</a>
               <a href="#">커뮤니티 관리</a>
               <a href="#">건의내역</a>
             </nav>

--- a/src/app/admin/reservation-detail/page.jsx
+++ b/src/app/admin/reservation-detail/page.jsx
@@ -1,65 +1,93 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import axiosInstance from '../../../libs/api/instance';
 
 export default function ReservationDetailPage() {
-  const reservations = [
-    {
-      id: 1,
-      room: '스터디룸 01',
-      time: '15:00 ~ 17:00',
-      user: 'USER 01',
-      createdAt: '2024-08-31 14:51',
-    },
-    {
-      id: 2,
-      room: '스터디룸 02',
-      time: '17:00 ~ 19:00',
-      user: 'USER 02',
-      createdAt: '2024-08-31 14:30',
-    },
-    {
-      id: 3,
-      room: '스터디룸 04',
-      time: '01:00 ~ 03:00',
-      user: 'USER 03',
-      createdAt: '2024-08-31 14:02',
-    },
-  ];
+  const [reservations, setReservations] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const fetchReservations = async () => {
+    try {
+      const response = await axiosInstance.get('/admin/reservations');
+      console.log('예약 데이터:', response.data);
+
+      setReservations(
+        (response.data.reservations || []).sort((a, b) => {
+          const dateA = new Date(...a.createdAt);
+          const dateB = new Date(...b.createdAt);
+          return dateB - dateA;
+        }),
+      );
+    } catch (err) {
+      console.error('예약 불러오기 실패:', err);
+      setError('예약 정보를 불러오는 데 실패했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchReservations();
+  }, []);
 
   return (
     <div className="bg-[#F1F2F4] p-6 min-h-screen">
       <div className="bg-white p-4 rounded-lg shadow-sm">
         <h1 className="text-lg font-semibold mb-4">예약 현황</h1>
 
-        <table className="w-full text-sm text-left">
-          <thead className="bg-[#F7F7F7] border-b text-[#333]">
-            <tr>
-              <th className="py-3 px-2 w-8">#</th>
-              <th className="py-3 px-2">스터디룸</th>
-              <th className="py-3 px-2">예약 시간</th>
-              <th className="py-3 px-2">사용자</th>
-              <th className="py-3 px-2">예약일</th>
-            </tr>
-          </thead>
-          <tbody className="bg-white">
-            {reservations.map((item, index) => (
-              <tr
-                key={item.id}
-                className="border-b hover:bg-gray-50 transition"
-              >
-                <td className="py-3 px-2">{index + 1}</td>
-                <td className="py-3 px-2">{item.room}</td>
-                <td className="py-3 px-2 text-[#788DFF]">{item.time}</td>
-                <td className="py-3 px-2">{item.user}</td>
-                <td className="py-3 px-2 text-xs text-gray-500">
-                  {item.createdAt}
-                </td>
+        {loading && <p>로딩 중...</p>}
+        {error && <p className="text-red-500">{error}</p>}
+
+        {!loading && !error && (
+          <table className="w-full text-sm text-left">
+            <thead className="bg-[#F7F7F7] border-b text-[#333]">
+              <tr>
+                <th className="py-3 px-2 w-8">#</th>
+                <th className="py-3 px-2">스터디룸</th>
+                <th className="py-3 px-2">예약 시간</th>
+                <th className="py-3 px-2">사용자 ID</th>
+                <th className="py-3 px-2">예약일</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody className="bg-white">
+              {reservations.map((item, index) => (
+                <tr
+                  key={item.id}
+                  className="border-b hover:bg-gray-50 transition"
+                >
+                  <td className="py-3 px-2">{index + 1}</td>
+                  <td className="py-3 px-2">스터디룸 {item.roomName}</td>
+                  <td className="py-3 px-2 text-[#788DFF]">
+                    {formatTimeRange(item.startTime, item.endTime)}
+                  </td>
+                  <td className="py-3 px-2">{item.userId}</td>
+                  <td className="py-3 px-2 text-xs text-gray-500">
+                    {formatDate(item.createdAt)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
       </div>
     </div>
   );
+}
+
+function formatHM(array) {
+  if (!Array.isArray(array)) return '';
+  const [_, __, ___, h = 0, m = 0] = array;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+function formatTimeRange(start, end) {
+  return `${formatHM(start)} ~ ${formatHM(end)}`;
+}
+
+function formatDate(arr) {
+  if (!Array.isArray(arr)) return '';
+  const [y, mo, d, h = 0, m = 0] = arr;
+  return `${y}-${String(mo).padStart(2, '0')}-${String(d).padStart(2, '0')} ${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
 }

--- a/src/app/admin/reservation-detail/page.jsx
+++ b/src/app/admin/reservation-detail/page.jsx
@@ -35,7 +35,7 @@ export default function ReservationDetailPage() {
   return (
     <div className="bg-[#F1F2F4] p-6 min-h-screen">
       <div className="bg-white p-4 rounded-lg shadow-sm">
-        <h1 className="text-lg font-semibold mb-4">예약 현황</h1>
+        <h1 className="text-lg font-semibold mb-4">예약 목록</h1>
 
         {loading && <p>로딩 중...</p>}
         {error && <p className="text-red-500">{error}</p>}

--- a/src/app/admin/reservations-by-date/page.jsx
+++ b/src/app/admin/reservations-by-date/page.jsx
@@ -1,0 +1,107 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import axiosInstance from '../../../libs/api/instance';
+import ReservationCard from '@components/admin/ReservationCard';
+
+export default function ReservationListPage() {
+  const [groupedReservations, setGroupedReservations] = useState({});
+  const [sortedDates, setSortedDates] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const fetchAllReservations = async () => {
+    try {
+      const response = await axiosInstance.get('/admin/reservations');
+      console.log('전체 예약 응답:', response);
+
+      const reservations = response.data.reservations || [];
+
+      // 날짜별 그룹핑
+      const grouped = {};
+      reservations.forEach((r) => {
+        const key = formatDateOnly(r.createdAt);
+        if (!grouped[key]) grouped[key] = [];
+        grouped[key].push(r);
+      });
+
+      Object.keys(grouped).forEach((date) => {
+        grouped[date].sort(
+          (a, b) => new Date(...b.createdAt) - new Date(...a.createdAt),
+        );
+      });
+
+      const sortedDateKeys = Object.keys(grouped).sort(
+        (a, b) => new Date(b) - new Date(a),
+      );
+
+      setGroupedReservations(grouped);
+      setSortedDates(sortedDateKeys);
+    } catch (err) {
+      console.error('전체 예약 불러오기 실패:', err);
+      setError('전체 예약 정보를 불러오는 데 실패했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAllReservations();
+  }, []);
+
+  return (
+    <div className="bg-[#F1F2F4] p-6 min-h-screen">
+      <div className="bg-white p-4 rounded-lg shadow-sm">
+        <h1 className="text-lg font-semibold mb-4">날짜별 예약 현황</h1>
+
+        {loading && <p>로딩 중...</p>}
+        {error && <p className="text-red-500">{error}</p>}
+
+        {!loading &&
+          !error &&
+          sortedDates.map((date) => (
+            <div key={date} className="mb-6">
+              <h2 className="text-md font-bold mb-2 border-b pb-1">
+                {date} 예약 내역
+              </h2>
+              <div className="grid gap-3">
+                {groupedReservations[date].map((item) => (
+                  <ReservationCard
+                    key={item.id}
+                    roomName={`스터디룸 ${item.roomName}`}
+                    time={formatTimeRange(item.startTime, item.endTime)}
+                    userName={`사용자 ID: ${item.userId}`}
+                    timestamp={formatFullDate(item.createdAt)}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+}
+
+// 날짜 key용 YYYY-MM-DD
+function formatDateOnly(arr) {
+  const [y, mo, d] = arr;
+  return `${y}-${String(mo).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+}
+
+// 전체 날짜 & 시간 포맷
+function formatFullDate(arr) {
+  if (!Array.isArray(arr)) return '';
+  const [y, mo, d, h = 0, m = 0] = arr;
+  return `${y}-${String(mo).padStart(2, '0')}-${String(d).padStart(2, '0')} ${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+// 시간 범위 포맷
+function formatHM(array) {
+  if (!Array.isArray(array)) return '';
+  const [_, __, ___, h = 0, m = 0] = array;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+function formatTimeRange(start, end) {
+  return `${formatHM(start)} ~ ${formatHM(end)}`;
+}

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -7,7 +7,7 @@ export const metadata = {
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="en">
+    <html lang="ko">
       <body>{children}</body>
     </html>
   );

--- a/src/components/admin/UserTableRow.jsx
+++ b/src/components/admin/UserTableRow.jsx
@@ -11,7 +11,7 @@ export default function UserTableRow({ user }) {
   return (
     <tr className="border-b hover:bg-gray-50 transition">
       <td className="py-3 px-2 text-[#666]">{user.id}</td>
-      <td className="py-3 px-2">{user.name}</td>
+      <td className="py-3 px-2">{user.username}</td>
       <td className="py-3 px-2">{user.email}</td>
       <td className="py-3 px-2 text-center">
         <button


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/admin-reservation-api

### 💡 작업개요
- 관리자 페이지에서 백엔드 `/admin/reservations` API를 연동하여 예약 데이터를 실시간으로 가져오고, 이를 날짜 기준으로 그룹핑 및 정렬하여 UI에 표시하는 기능 구현
- 기존에는 프론트엔드 더미 데이터 또는 고정 목록을 기반으로 UI만 구성되어 있었으나, 이번 작업을 통해 실제 API 응답을 기반으로 한 실시간 예약 내역 조회 가능

### 🔑 주요 변경사항 
1. 예약 API 연동 및 데이터 처리
- `/admin/reservations` GET API 호출하여 전체 예약 데이터 수신
- 응답 데이터 중 `createdAt` 배열을 활용하여 날짜(YYYY-MM-DD) 기준으로 그룹핑
- 그룹핑된 각 날짜 그룹 내 예약들을 최신순(`createdAt`)으로 정렬 처리

2. UI에 그룹핑된 예약 목록 렌더링
- 날짜별 구간 헤더(`YYYY-MM-DD 예약 내역`)를 기준으로 `ReservationCard` 컴포넌트 리스트 렌더링
- 각 카드에는 스터디룸 이름, 예약 시간 범위, 사용자 ID, 예약 생성일시 등을 표시

3. 관리자 대시보드 요약 기능 추가
- 오늘/내일 예약만 필터링하여 랜덤 3건씩 `ReservationCard`로 요약 표시
- 예약이 없을 경우 `예약 없음` 안내 문구 출력

4. 기타 보완 작업
- 예약 목록 관련 사이드바 라우팅 및 메뉴 정리 (`/admin/reservations-by-date`, `/admin/reservation-detail`)
- 기본 언어 설정 `lang="en"` → `"ko"`로 변경하여 HTML 접근성 및 SEO 개선
- 아직 연동되지 않은 불필요한 텍스트 수정 및 UI 정비

### 🏞 스크린샷


### 🔗 관련 이슈 
- #44 