### PR TITLE
Feat/add email code timer

### DIFF
--- a/src/app/login/sign-up-step3/page.jsx
+++ b/src/app/login/sign-up-step3/page.jsx
@@ -48,7 +48,7 @@ export default function Login() {
 
       console.log('회원가입 성공:', res.data);
       resetSignupData();
-      router.push('/login/sign-up-step4');
+      router.push(`/login/sign-up-step4?username=${encodeURIComponent(name)}`);
     } catch (error) {
       console.error('회원가입 실패:', error);
       alert(

--- a/src/app/login/sign-up-step4/page.jsx
+++ b/src/app/login/sign-up-step4/page.jsx
@@ -3,8 +3,12 @@ import CustomizedStepper from './customizedStepper';
 import React from 'react';
 import Button from '../../../components/common/Button';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 
 export default function Login() {
+  const searchParams = useSearchParams();
+  const username = searchParams.get('username') || 'USER 01';
+  
   const handleSignup = () => {
     console.log('확인 버튼 클릭:', '회원가입 성공');
   };
@@ -33,7 +37,7 @@ export default function Login() {
           </div>
           <div className="flex flex-col items-center text-center">
             <div className="text-[14px]">
-              USER 01님의 회원가입을 축하합니다.
+              {username}님의 회원가입을 축하합니다.
             </div>
             <div className="text-[14px]">띵스룸을 통해 빠르고 쾌적하게</div>
             <div className="text-[14px]">스터디룸을 이용할 수 있어요!</div>


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/reservation-global-sync

### 💡 작업개요
- 회원가입 과정에서 인증번호 타이머 및 확인 버튼 기능을 추가하여 사용자 편의성과 보안성을 강화
- 회원가입 완료 페이지에서 URL 파라미터 기반 사용자명 동적 표시 기능을 구현하여 개인화된 UX 제공

### 🔑 주요 변경사항 
1. 회원가입 인증번호 기능 개선
- 타이머 기능 추가: 인증번호 전송 후 유효 시간 카운트다운 구현 (5분)
- 인증번호 확인 버튼 구현: 입력된 인증번호를 서버 검증 API로 요청
- 버튼 UI 조정: ‘인증번호 전송’과 ‘인증번호 확인’ 버튼의 크기 및 높이를 동일하게 맞추고, input 영역 비율 최적화
- 잘못된 입력 시 에러 메시지 출력 및 재입력 가능 처리

2. 회원가입 완료 페이지 사용자명 표시 기능
- 회원가입 성공 시, sign-up-step3에서 `username`을 URL 파라미터로 전달
- sign-up-step4에서 `useSearchParams`를 통해 해당 파라미터 값을 추출
- 기존 고정 텍스트 `"USER 01"` → 동적 `{username}` 변수로 변경
- 사용자별 맞춤 환영 메시지 구현 (예: `유진님, 가입을 환영합니다!`)

### 🏞 스크린샷
<img width="330" height="716" alt="image" src="https://github.com/user-attachments/assets/f6f2326a-4eff-4e63-8d8f-d68c2aebd0e0" />


### 🔗 관련 이슈 
- #