### PR TITLE
[Feat] 비밀번호 재설정 1단계 페이지에 인증번호 확인 버튼 및 타이머 검증 기능 추가

### DIFF
--- a/src/app/login/reset-password-step1/page.jsx
+++ b/src/app/login/reset-password-step1/page.jsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import Button from '../../../components/common/Button';
 import Link from 'next/link';
 import axiosInstance from '../../../libs/api/instance';
@@ -8,21 +8,68 @@ import { strictEmailRegex } from '../../../constants/regex';
 export default function ResetPassWord1() {
   const [email, setEmail] = useState('');
   const [number, setNumber] = useState('');
+
   const [isCodeVerified, setIsCodeVerified] = useState(false);
   const [emailError, setEmailError] = useState('');
   const [numberError, setNumberError] = useState('');
   const [codeVerificationMessage, setCodeVerificationMessage] = useState('');
 
-  const verificationToken = useRef(0);
+  const [isSending, setIsSending] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
+
+  const [secondsLeft, setSecondsLeft] = useState(0);
+  const [codeSent, setCodeSent] = useState(false);
+  const timerRef = useRef(null);
+
+  const commonCodeButtonClass =
+    'inline-flex items-center justify-center w-[100px] h-10 ' +
+    'border border-[#788cff] bg-white text-[#788cff] ' +
+    'hover:bg-[#788cff] hover:text-white text-sm font-medium rounded-lg ' +
+    'transition-all duration-200 whitespace-nowrap disabled:opacity-50';
+
+  const startTimer = () => {
+    setSecondsLeft(300);
+    if (timerRef.current) clearInterval(timerRef.current);
+    timerRef.current = setInterval(() => {
+      setSecondsLeft((prev) => {
+        if (prev <= 1) {
+          clearInterval(timerRef.current);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, []);
+
+  const mmss = useMemo(() => {
+    const m = String(Math.floor(secondsLeft / 60)).padStart(2, '0');
+    const s = String(secondsLeft % 60).padStart(2, '0');
+    return `${m}:${s}`;
+  }, [secondsLeft]);
 
   const handleSendCode = async () => {
     try {
+      setCodeVerificationMessage('');
+      setNumberError('');
+      setIsCodeVerified(false);
+
       if (!strictEmailRegex.test(email)) {
         setEmailError('유효한 학교 이메일을 입력해주세요. (@mju.ac.kr)');
         return;
       }
+      setEmailError('');
+      setIsSending(true);
 
       await axiosInstance.post('/user/code-send', { email });
+
+      setCodeSent(true);
+      startTimer();
       alert('인증번호가 이메일로 전송되었습니다.');
     } catch (error) {
       console.error('인증번호 전송 실패:', error);
@@ -30,41 +77,74 @@ export default function ResetPassWord1() {
         error?.response?.data?.message ||
           '인증번호 전송에 실패했습니다. 다시 시도해주세요.',
       );
+      setCodeSent(false);
+      setSecondsLeft(0);
+    } finally {
+      setIsSending(false);
     }
   };
 
-  const handleCodeInput = async (value) => {
-    setNumber(value);
+  const handleCodeInput = (value) => {
+    const v = value.replace(/\s/g, '');
+    setNumber(v);
     setIsCodeVerified(false);
-    setNumberError('');
     setCodeVerificationMessage('');
-
-    if (!/^[0-9]{6}$/.test(value)) {
+    if (v && !/^[0-9]{6}$/.test(v)) {
       setNumberError('6자리 숫자 인증번호를 입력해주세요.');
-      return;
+    } else {
+      setNumberError('');
     }
+  };
 
-    const currentToken = ++verificationToken.current;
-
+  const handleVerifyCode = async () => {
     try {
+      setIsVerifying(true);
+      setCodeVerificationMessage('');
+      setIsCodeVerified(false);
+
+      if (!codeSent) {
+        setCodeVerificationMessage('먼저 인증번호를 전송해주세요.');
+        return;
+      }
+      if (secondsLeft <= 0) {
+        setCodeVerificationMessage(
+          '인증번호가 만료되었습니다. 다시 전송해주세요.',
+        );
+        return;
+      }
+      if (!/^[0-9]{6}$/.test(number)) {
+        setNumberError('6자리 숫자 인증번호를 입력해주세요.');
+        return;
+      }
+
       const res = await axiosInstance.post('/user/code-verify', {
         email,
-        code: value,
+        code: number,
       });
 
-      if (verificationToken.current === currentToken) {
+      const ok =
+        (res?.data?.verified ?? res?.data?.success) === true ||
+        res?.status === 200;
+
+      if (ok) {
         setIsCodeVerified(true);
         setCodeVerificationMessage('인증 성공');
-      }
-    } catch (err) {
-      if (verificationToken.current === currentToken) {
+      } else {
         setIsCodeVerified(false);
         setCodeVerificationMessage('인증번호가 올바르지 않습니다.');
       }
+    } catch (err) {
+      console.error('인증번호 확인 실패:', err);
+      setIsCodeVerified(false);
+      setCodeVerificationMessage(
+        '인증번호 확인에 실패했습니다. 다시 시도해주세요.',
+      );
+    } finally {
+      setIsVerifying(false);
     }
   };
 
-  const handleLogin = () => {
+  const handleNext = () => {
     sessionStorage.setItem('resetEmail', email);
   };
 
@@ -104,10 +184,11 @@ export default function ResetPassWord1() {
                 />
               </div>
               <button
-                className="px-4 py-3 border border-[#788cff] bg-white text-[#788cff] hover:bg-[#788cff] hover:text-white text-sm font-medium rounded-lg transition-all duration-200 whitespace-nowrap"
+                className={commonCodeButtonClass}
                 onClick={handleSendCode}
+                disabled={isSending || !strictEmailRegex.test(email)}
               >
-                인증번호전송
+                {isSending ? '전송중' : '인증번호 전송'}
               </button>
             </div>
             {emailError && (
@@ -119,14 +200,41 @@ export default function ResetPassWord1() {
             <label className="block text-sm font-medium text-[#37352f]">
               인증번호
             </label>
-            <StyledNumberInput
-              type="text"
-              id="number"
-              value={number}
-              onChange={(e) => handleCodeInput(e.target.value)}
-              placeholder="이메일로 전송된 인증번호를 입력해주세요."
-              inputMode="numeric"
-            />
+
+            <div className="flex items-center gap-3">
+              <div className="relative flex-1 min-w-0">
+                <StyledNumberInput
+                  type="text"
+                  id="number"
+                  value={number}
+                  onChange={(e) => handleCodeInput(e.target.value)}
+                  placeholder="이메일로 전송된 인증번호를 입력해주세요."
+                  inputMode="numeric"
+                  maxLength={6}
+                  className="pr-14"
+                />
+                {codeSent && (
+                  <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-[#666]">
+                    {secondsLeft > 0 ? mmss : '만료'}
+                  </span>
+                )}
+              </div>
+
+              {/* 새로 추가된 확인 버튼 */}
+              <button
+                className={commonCodeButtonClass}
+                onClick={handleVerifyCode}
+                disabled={
+                  isVerifying ||
+                  !codeSent ||
+                  secondsLeft <= 0 ||
+                  !/^[0-9]{6}$/.test(number)
+                }
+              >
+                {isVerifying ? '확인중' : '인증번호 확인'}
+              </button>
+            </div>
+
             {numberError && (
               <p className="text-red-500 text-xs mt-1.5">{numberError}</p>
             )}
@@ -144,9 +252,12 @@ export default function ResetPassWord1() {
       </div>
 
       <div className="max-w-md mx-auto w-full mt-8">
-        <Link href={isCodeVerified ? '/login/reset-password-step2' : '#'}>
+        <Link
+          href={isCodeVerified ? '/login/reset-password-step2' : '#'}
+          onClick={(e) => !isCodeVerified && e.preventDefault()}
+        >
           <Button
-            onClick={handleLogin}
+            onClick={handleNext}
             disabled={!isCodeVerified}
             text="다음으로"
           />
@@ -156,10 +267,10 @@ export default function ResetPassWord1() {
   );
 }
 
-const StyledInput = ({ value, ...props }) => {
+const StyledInput = ({ value, className = '', ...props }) => {
   return (
     <input
-      className="w-full px-4 py-3 bg-white rounded-lg border border-[#e9e9e7] text-sm placeholder:text-[#9b9998] focus:outline-none focus:border-[#788cff] focus:ring-2 focus:ring-[#788cff]/10 transition-all duration-200"
+      className={`w-full px-4 py-3 bg-white rounded-lg border border-[#e9e9e7] text-sm placeholder:text-[#9b9998] focus:outline-none focus:border-[#788cff] focus:ring-2 focus:ring-[#788cff]/10 transition-all duration-200 ${className}`}
       value={value}
       {...props}
     />
@@ -193,6 +304,6 @@ const StyledEmailInput = ({ value, setEmail, ...props }) => {
   );
 };
 
-const StyledNumberInput = ({ value, ...props }) => {
-  return <StyledInput {...props} value={value} />;
+const StyledNumberInput = ({ value, className = '', ...props }) => {
+  return <StyledInput {...props} value={value} className={className} />;
 };


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/reset-password-verification

### 💡 작업개요
- 기존 비밀번호 재설정 1단계 페이지에서는 인증번호 전송 후 즉시 입력만 가능하고, 유효성 및 만료 여부를 명시적으로 검증하는 기능 존재x
- 회원가입 페이지에 적용된 타이머 기능과 인증번호 확인 버튼 로직을 동일하게 적용하여, 인증 절차의 명확성과 보안 강화

### 🔑 주요 변경사항 
1. UI 개선
- 인증번호 입력창 우측에 `인증번호 확인` 버튼 추가
- 버튼 상태가 `확인중`, `비활성화`, `활성화`로 상황에 따라 변경되도록 구현
- 인증번호 전송 시 타이머(5분)가 표시되며, 만료 시 만료 문구로 변경

2. 타이머 검증 로직
- 인증번호 전송 시 300초(5분) 타이머 시작
- 타이머 만료 시 `인증번호 확인` 버튼 비활성화
- 재전송 시 타이머가 초기화되도록 처리

3. 인증번호 확인 로직
- 버튼 클릭 시 서버(`/user/code-verify`)로 인증번호 검증 요청
- 유효성 검증:
-- 입력값이 6자리 숫자인지 확인
-- 인증번호 전송 상태(`codeSent`) 확인
-- 타이머 만료 여부(`secondsLeft > 0`) 확인
- 인증 성공 시:
-- `isCodeVerified` 상태를 `true`로 변경
-- "인증 성공" 메시지를 초록색으로 표시
-- `다음으로` 버튼 활성화
- 인증 실패 시:
-- `isCodeVerified` 상태를 `false`로 변경
-- 실패 원인에 따른 안내 메시지 출력

4. 다음 단계 이동 조건 변경
- 인증 성공 상태(`isCodeVerified === true`)일 때만 `/login/reset-password-step2`로 이동 가능
- 인증 실패 시에는 이동 불가

### 🏞 스크린샷
<img width="333" height="718" alt="image" src="https://github.com/user-attachments/assets/6f1308fc-76dc-4801-91e7-0a312339e531" />


### 🔗 관련 이슈 
- #