### PR TITLE
[Feat] 비로그인 접근 시 통일된 모달 안내 및 즉시 로그인 리다이렉트 구현

### DIFF
--- a/src/app/login/page.jsx
+++ b/src/app/login/page.jsx
@@ -1,7 +1,7 @@
 'use client';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import axios from 'axios';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import Button from '../../components/common/Button';
 import { isValidPassword, strictEmailRegex } from '../../constants/regex';
@@ -20,9 +20,18 @@ export default function Login() {
   const [newPassword_2, setnewPassword_2] = useState('');
 
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const [redirectUrl, setRedirectUrl] = useState('/');
 
   const { setAccessToken: setGlobalAccessToken, setRefreshToken } =
     useTokenStore();
+
+  useEffect(() => {
+    const redirect = searchParams.get('redirect');
+    if (redirect) {
+      setRedirectUrl(decodeURIComponent(redirect));
+    }
+  }, [searchParams]);
 
   const handleLoginSave = () => {
     setIsLoginSave(!isLoginSave);
@@ -58,7 +67,7 @@ export default function Login() {
         setRefreshToken(refreshToken || '');
         const decoded = jwtDecode(accessToken);
         console.log('토큰 디코드 결과:', decoded);
-        router.push('/');
+        router.push(redirectUrl);
       } else {
         // 디버깅용 로그
         console.warn(

--- a/src/app/my/account-info/page.jsx
+++ b/src/app/my/account-info/page.jsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import MyPageHeader from '@components/common/MyPageHeader';
 import MyPageBlock from '@components/common/MyPageBlock';
 import Modal from '@components/common/Modal';
+import LoginRequiredModal from '@components/common/LoginRequiredModal';
 import { jwtDecode } from 'jwt-decode';
 import useTokenStore from '../../../stores/useTokenStore';
 import axiosInstance from '../../../libs/api/instance';
@@ -11,6 +12,7 @@ import axiosInstance from '../../../libs/api/instance';
 export default function AccountInfo() {
   const [open, setOpen] = useState(false);
   const [newName, setNewName] = useState('');
+  const [showLoginModal, setShowLoginModal] = useState(false);
   const { accessToken, userId } = useTokenStore();
 
   const getDecodedUserInfo = () => {
@@ -27,10 +29,14 @@ export default function AccountInfo() {
 
   useEffect(() => {
     if (!accessToken) {
-      alert('로그인이 필요한 기능입니다.');
-      window.location.href = '/login';
+      setShowLoginModal(true);
     }
   }, [accessToken]);
+
+  const handleLoginConfirm = () => {
+    const currentPath = window.location.pathname;
+    window.location.href = `/login?redirect=${encodeURIComponent(currentPath)}`;
+  };
 
   const handleUsernameChange = async () => {
     try {
@@ -137,6 +143,11 @@ export default function AccountInfo() {
           </div>
         </div>
       </Modal>
+      
+      <LoginRequiredModal 
+        isOpen={showLoginModal} 
+        onConfirm={handleLoginConfirm} 
+      />
     </div>
   );
 }

--- a/src/app/my/cancel-account-step1/page.jsx
+++ b/src/app/my/cancel-account-step1/page.jsx
@@ -1,18 +1,31 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import axiosInstance from '../../../libs/api/instance';
 import MyPageHeader from '@components/common/MyPageHeader';
 import Modal from '@components/common/Modal';
+import LoginRequiredModal from '@components/common/LoginRequiredModal';
 import useTokenStore from '../../../stores/useTokenStore';
 
 export default function CancelAccountStep1() {
   const [open, setOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [email, setEmail] = useState('');
+  const [showLoginModal, setShowLoginModal] = useState(false);
   const { accessToken } = useTokenStore();
   const router = useRouter();
+
+  useEffect(() => {
+    if (!accessToken) {
+      setShowLoginModal(true);
+    }
+  }, [accessToken]);
+
+  const handleLoginConfirm = () => {
+    const currentPath = window.location.pathname;
+    window.location.href = `/login?redirect=${encodeURIComponent(currentPath)}`;
+  };
 
   const handleDeleteAccount = async () => {
     if (!email || !accessToken) {
@@ -95,6 +108,11 @@ export default function CancelAccountStep1() {
           </Modal>
         </div>
       </div>
+
+      <LoginRequiredModal
+        isOpen={showLoginModal}
+        onConfirm={handleLoginConfirm}
+      />
     </>
   );
 }

--- a/src/app/my/reservation-list/page.jsx
+++ b/src/app/my/reservation-list/page.jsx
@@ -1,14 +1,35 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import MyPageHeader from '@components/common/MyPageHeader';
 import ReservationList from '@components/common/ReservationList';
+import LoginRequiredModal from '@components/common/LoginRequiredModal';
+import useTokenStore from '../../../stores/useTokenStore';
 
 export default function ReservationInfo() {
+  const [showLoginModal, setShowLoginModal] = useState(false);
+  const { accessToken } = useTokenStore();
+
+  useEffect(() => {
+    if (!accessToken) {
+      setShowLoginModal(true);
+    }
+  }, [accessToken]);
+
+  const handleLoginConfirm = () => {
+    const currentPath = window.location.pathname;
+    window.location.href = `/login?redirect=${encodeURIComponent(currentPath)}`;
+  };
+
   return (
     <div className="w-full">
       <MyPageHeader />
       <ReservationList />
+
+      <LoginRequiredModal
+        isOpen={showLoginModal}
+        onConfirm={handleLoginConfirm}
+      />
     </div>
   );
 }

--- a/src/components/common/LoginRequiredModal.jsx
+++ b/src/components/common/LoginRequiredModal.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+const LoginRequiredModal = ({ isOpen, onConfirm }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex justify-center items-center z-[9999] backdrop-blur-sm">
+      <div
+        className="bg-white rounded-2xl w-[90%] max-w-[400px] mx-4 shadow-2xl border border-gray-100 overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="p-6 text-center">
+          <h3 className="text-lg font-semibold text-[#37352f] mb-4">
+            로그인이 필요한 기능입니다
+          </h3>
+          <p className="text-sm text-[#73726e] mb-6">
+            이 페이지를 이용하려면 로그인이 필요합니다.
+          </p>
+        </div>
+
+        <div className="border-t border-gray-100">
+          <button
+            onClick={onConfirm}
+            className="w-full py-4 bg-[#788cff] text-white text-sm font-medium hover:bg-[#6a7dff] transition-colors"
+          >
+            확인
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LoginRequiredModal;

--- a/src/components/common/ReservationComponent.jsx
+++ b/src/components/common/ReservationComponent.jsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import TimeComponent from '@components/common/TimeComponent';
 import Modal from '@components/common/Modal';
+import LoginRequiredModal from '@components/common/LoginRequiredModal';
 import useTokenStore from '../../stores/useTokenStore';
 import useReservationStore from '../../stores/useReservationStore';
 import axiosInstance from '../../libs/api/instance';
@@ -20,6 +21,7 @@ const ReservationComponent = ({ index, roomId }) => {
   const [open, setOpen] = useState(false);
   const [startTime, setStartTime] = useState('');
   const [endTime, setEndTime] = useState('');
+  const [showLoginModal, setShowLoginModal] = useState(false);
 
   const { userId, accessToken } = useTokenStore();
   const {
@@ -63,11 +65,15 @@ const ReservationComponent = ({ index, roomId }) => {
 
   const handleOpenModal = () => {
     if (!accessToken) {
-      alert('로그인이 필요합니다.');
-      router.push('/login');
+      setShowLoginModal(true);
       return;
     }
     setOpen(true);
+  };
+
+  const handleModalConfirm = () => {
+    setShowLoginModal(false);
+    router.push('/login');
   };
 
   const handleSubmitReservation = async () => {
@@ -269,6 +275,10 @@ const ReservationComponent = ({ index, roomId }) => {
       </div>
       <div className="mt-4 flex flex-col w-full">{renderTimeBlocks()}</div>
       <div className="bg-[#9999A3] h-0.5 w-full mt-3" />
+      <LoginRequiredModal
+        isOpen={showLoginModal}
+        onConfirm={handleModalConfirm}
+      />
     </div>
   );
 };

--- a/src/components/common/SecondBanner.jsx
+++ b/src/components/common/SecondBanner.jsx
@@ -2,19 +2,25 @@
 
 import { useRouter } from 'next/navigation';
 import useTokenStore from '../../stores/useTokenStore';
-import React from 'react';
+import React, { useState } from 'react';
+import LoginRequiredModal from './LoginRequiredModal';
 
 const SecondBanner = () => {
   const router = useRouter();
   const { accessToken } = useTokenStore();
+  const [showLoginModal, setShowLoginModal] = useState(false);
 
   const handleReserveClick = () => {
     if (!accessToken) {
-      alert('로그인이 필요합니다.');
-      router.push('/login');
+      setShowLoginModal(true);
       return;
     }
     router.push('/');
+  };
+
+  const handleModalConfirm = () => {
+    setShowLoginModal(false);
+    router.push('/login');
   };
 
   return (
@@ -32,6 +38,10 @@ const SecondBanner = () => {
           예약하기
         </button>
       </div>
+      <LoginRequiredModal
+        isOpen={showLoginModal}
+        onConfirm={handleModalConfirm}
+      />
     </div>
   );
 };

--- a/src/components/common/TomorrowReservationComponent.jsx
+++ b/src/components/common/TomorrowReservationComponent.jsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import TimeComponent from '@components/common/TimeComponent';
 import Modal from '@components/common/Modal';
+import LoginRequiredModal from '@components/common/LoginRequiredModal';
 import useTokenStore from '../../stores/useTokenStore';
 import useReservationStore from '../../stores/useReservationStore';
 import axiosInstance from '../../libs/api/instance';
@@ -20,6 +21,7 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
   const [open, setOpen] = useState(false);
   const [startTime, setStartTime] = useState('');
   const [endTime, setEndTime] = useState('');
+  const [showLoginModal, setShowLoginModal] = useState(false);
 
   const { userId, accessToken } = useTokenStore();
   const {
@@ -69,11 +71,15 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
 
   const handleOpenModal = () => {
     if (!accessToken) {
-      alert('로그인이 필요합니다.');
-      router.push('/login');
+      setShowLoginModal(true);
       return;
     }
     setOpen(true);
+  };
+
+  const handleModalConfirm = () => {
+    setShowLoginModal(false);
+    router.push('/login');
   };
 
   const handleSubmitReservation = async () => {
@@ -254,6 +260,10 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
       </div>
       <div className="mt-4 flex flex-col w-full">{renderTimeBlocks()}</div>
       <div className="bg-[#9999A3] h-0.5 w-full mt-3" />
+      <LoginRequiredModal
+        isOpen={showLoginModal}
+        onConfirm={handleModalConfirm}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/auth-guard-login-redirect

### 💡 작업개요
- 비로그인 사용자가 마이페이지 또는 예약 관련 기능에 접근할 경우, 기존에는 `alert()` 팝업 후 확인 버튼을 2회 클릭해야 로그인 페이지로 이동하는 불편함 존재
- 통일된 디자인의 `LoginRequiredModal` 컴포넌트를 도입하여 모든 인증 가드 상황에서 일관된 UI/UX를 제공하고, 확인 버튼 클릭 시 즉시 로그인 페이지로 이동하도록 개선
- 로그인 완료 후 원래 접근하려던 페이지로 자동 복귀하는 리다이렉트 로직 구현


### 🔑 주요 변경사항 
1. LoginRequiredModal 컴포넌트 생성 (`src/components/common/LoginRequiredModal.jsx`)
- "로그인이 필요한 기능입니다" 메시지와 '확인' 버튼 포함
- `onConfirm` 시 로그인 페이지로 이동하며, 현재 경로를 `redirect` 파라미터로 전달

2. 마이페이지 인증 로직 개선
- 수정 파일:
-- `src/app/my/account-info/page.jsx`
-- `src/app/my/cancel-account-step1/page.jsx`
-- `src/app/my/reservation-list/page.jsx`
- 기존: 토큰이 없으면 즉시 로그인 페이지로 리다이렉트
- 변경: 토큰이 없으면 `LoginRequiredModal` 표시 → 확인 클릭 시 로그인 페이지 이동
- 로그인 성공 시 `redirect` 파라미터를 통해 원래 접근 페이지로 복귀

3. 예약 관련 컴포넌트의 인증 안내 통일
- 수정 파일:
-- `SecondBanner.jsx`
-- `ReservationComponent.jsx`
-- `TomorrowReservationComponent.jsx`
- 기존: 비로그인 시 `alert()` 호출
- 변경: `LoginRequiredModal` 표시 → 확인 클릭 시 로그인 페이지 이동
- 각 컴포넌트에 `showLoginModal` 상태 및 `LoginRequiredModal` import 추가

4. 동작 흐름 개선
- 비로그인 사용자가 접근 → 모달 표시 → 확인 버튼 한 번으로 로그인 페이지 이동
- 로그인 완료 시 기존 접근 페이지로 자동 복귀 (없으면 메인 페이지로 이동)


### 🏞 스크린샷
<img width="330" height="721" alt="image" src="https://github.com/user-attachments/assets/2b163253-1ad8-418a-86bb-4e42de623499" />

### 🔗 관련 이슈 
- #92