### PR TITLE
[Fix] /my/account-info 페이지에서 뒤로가기 시 홈으로 이동하도록 수정

### DIFF
--- a/src/components/common/MyPageHeader.jsx
+++ b/src/components/common/MyPageHeader.jsx
@@ -1,14 +1,23 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 
 const MyPageHeader = () => {
   const router = useRouter();
+  const pathname = usePathname();
+
+  const handleBack = () => {
+    if (pathname === '/my/account-info') {
+      router.push('/');
+    } else {
+      router.back();
+    }
+  };
 
   return (
     <header className="flex items-center px-6 py-4 pt-12 pb-8 bg-white border-b border-gray-100 relative">
       <button
-        onClick={() => router.back()}
+        onClick={handleBack}
         className="p-2 hover:bg-gray-50 rounded-lg transition-colors -ml-2"
       >
         <img


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/auth-guard-login-redirect

### 💡 작업개요
- /my/account-info 페이지에서 뒤로가기 버튼 클릭 시 홈(/)으로 이동하지 않고 이전 페이지로만 돌아가던 문제를 수정
- 특정 페이지에서만 뒤로가기 동작을 변경하고, 나머지 마이페이지 경로에서는 기존 로직을 유지하여 페이지 전환의 일관성 보장

### 🔑 주요 변경사항 
1.  현재 경로 식별 로직 추가
  - MyPageHeader.jsx에 `usePathname` 훅을 도입하여 현재 페이지 경로를 확인
2. 뒤로가기 동작 조건부 처리
  - `/my/account-info` 경로일 경우 → `router.push('/')`를 통해 홈으로 이동
  - 그 외 경로는 기존 `router.back()` 동작 유지
3. 기존 페이지 로직 보존
  - `/my/reservation-list`, `/my/cancel-account-step1` 등 다른 마이페이지 경로는 기존 뒤로가기 동작 유지
4. UI 적용
  - 뒤로가기 버튼 클릭 이벤트에 수정된 `handleBack` 함수를 연결

### 🏞 스크린샷


### 🔗 관련 이슈 
- #96