### PR TITLE
[Feat] 비밀번호 검증 규칙 강화 — 최소 8자, 영문/숫자/특수문자 포함

### DIFF
--- a/src/app/login/reset-password-step2/page.jsx
+++ b/src/app/login/reset-password-step2/page.jsx
@@ -79,7 +79,7 @@ export default function ResetPassword2() {
                 setnewPassword(pw);
                 if (!isValidPassword(pw)) {
                   setPasswordError(
-                    '비밀번호는 8자 이상, 영문과 숫자를 포함해야 합니다.',
+                    '비밀번호는 8자 이상, 영문·숫자·특수문자를 모두 포함해야 합니다.',
                   );
                 } else {
                   setPasswordError('');

--- a/src/app/login/sign-up-step2/page.jsx
+++ b/src/app/login/sign-up-step2/page.jsx
@@ -67,7 +67,7 @@ export default function Login() {
               setnewPassword(pw);
               if (!isValidPassword(pw)) {
                 setPasswordError(
-                  '비밀번호는 8자 이상, 영문과 숫자를 포함해야 합니다.',
+                  '비밀번호는 8자 이상, 영문·숫자·특수문자를 모두 포함해야 합니다.',
                 );
               } else {
                 setPasswordError('');

--- a/src/constants/regex.js
+++ b/src/constants/regex.js
@@ -1,6 +1,7 @@
 export const strictEmailRegex = /^[a-zA-Z0-9._%+-]+@mju\.ac\.kr$/;
 // export const numberRegex = /^\d+$/;
-export const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
+export const passwordRegex =
+  /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?])[A-Za-z\d!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]{8,}$/;
 
 export const isValidPassword = (password) => {
   return passwordRegex.test(password);


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/password-validation-update

### 💡 작업개요
- 회원가입 및 비밀번호 재설정 단계의 비밀번호 유효성 검사 강화
- 기존 규칙(영문+숫자 조합)에서 최소 8자 & 영문/숫자/특수문자를 모두 포함하도록 변경했고, 이에 맞춰 에러 메시지 문구 통일

### 🔑 주요 변경사항 
1. 정규식 업데이트
- `src/constants/regex.js`비밀번호 패턴을 최소 8자, 영문/숫자/특수문자 각각 1자 이상으로 강화

- 기존보다 길이 조건을 8자 이상으로 상향하고, `특수문자` 포함 여부를 명시적으로 검사하도록 수정


2. 에러 메시지 문구 정렬

- `src/app/login/sign-up-step2/page.jsx` 에러 문구를 "8자 이상, 영문/숫자/특수문자 포함" 기준으로 수정
- `src/app/login/reset-password-step2/page.jsx` 동일 문구로 통일하여 UX 일관성 확보

3. 검증 정책 문서화(코드 내 주석)
- 정규식 위에 정책(최소 길이/필수 문자군) 주석으로 명시하여 추후 변경 시 가독성 및 유지보수성 향상

### 🏞 스크린샷


### 🔗 관련 이슈 
- #93 