### PR TITLE
[Fix] KST 기준 과거 시간 일괄 ‘검정색’ 표시 & 색상 안내 문구 추가 (+23:59 처리 보완)

### DIFF
--- a/src/components/common/AfterLoginBanner.jsx
+++ b/src/components/common/AfterLoginBanner.jsx
@@ -9,11 +9,8 @@ import axiosInstance from '../../libs/api/instance';
 const AfterLoginBanner = () => {
   const [openReservationId, setOpenReservationId] = useState(null);
   const { userId, accessToken } = useTokenStore();
-  const {
-    userReservations,
-    setUserReservations,
-    fetchAllReservedTimes, // ✅ 추가
-  } = useReservationStore();
+  const { userReservations, setUserReservations, fetchAllReservedTimes } =
+    useReservationStore();
 
   const parseDate = (raw) => {
     if (!raw) return null;
@@ -44,11 +41,8 @@ const AfterLoginBanner = () => {
       const nowKST = new Date();
 
       const upcoming = res.data.reservations.filter((r) => {
-        const rawStart = r.startTime || r.reservationStartTime;
-        const start = parseDate(rawStart);
-        return (
-          r.status === 'RESERVED' && start && start.getTime() > nowKST.getTime()
-        );
+        const endTime = parseDate(r.endTime);
+        return r.status === 'RESERVED' && endTime > nowKST;
       });
 
       const sorted = upcoming.sort(
@@ -72,8 +66,8 @@ const AfterLoginBanner = () => {
       });
       alert(res.data.message || '예약이 취소되었습니다.');
       setOpenReservationId(null);
-      await fetchAllUserReservations(); // ✅ 사용자 예약 상태 갱신
-      await fetchAllReservedTimes(); // ✅ 모든 예약 상태 갱신 (UI 색상 즉시 반영)
+      await fetchAllUserReservations();
+      await fetchAllReservedTimes();
     } catch (err) {
       console.error('예약 취소 실패:', err);
       alert(err.response?.data?.message || '예약 취소에 실패했습니다.');

--- a/src/components/common/ReservationComponent.jsx
+++ b/src/components/common/ReservationComponent.jsx
@@ -56,8 +56,8 @@ const ReservationComponent = ({ index, roomId }) => {
   };
 
   const getStatus = (time) => {
-    const timeDate = new Date(time);
     if (time.endsWith('23:59:00')) return 'display-only';
+    const timeDate = new Date(time);
     if (timeDate < now) return 'past';
     if (reservedTimeSlots.includes(time)) return 'reserved';
     return 'available';
@@ -274,6 +274,20 @@ const ReservationComponent = ({ index, roomId }) => {
         </Modal>
       </div>
       <div className="mt-4 flex flex-col w-full">{renderTimeBlocks()}</div>
+      <div className="mt-3 flex items-center gap-4 text-xs text-gray-600">
+        <div className="flex items-center gap-1">
+          <div className="w-2 h-2 bg-[#788DFF]"></div>
+          <span>예약 가능</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="w-2 h-2 bg-[#9999A3]"></div>
+          <span>예약됨</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="w-2 h-2 bg-[#000000]"></div>
+          <span>지난 시간</span>
+        </div>
+      </div>
       <div className="bg-[#9999A3] h-0.5 w-full mt-3" />
       <LoginRequiredModal
         isOpen={showLoginModal}

--- a/src/components/common/ReservationComponent.jsx
+++ b/src/components/common/ReservationComponent.jsx
@@ -9,6 +9,16 @@ import useTokenStore from '../../stores/useTokenStore';
 import useReservationStore from '../../stores/useReservationStore';
 import axiosInstance from '../../libs/api/instance';
 
+// KST(Asia/Seoul) 현재시각
+const nowInKST = () =>
+  new Date(new Date().toLocaleString('en-US', { timeZone: 'Asia/Seoul' }));
+
+// 기준 날짜(baseDate)와 HH:MM로 KST Date 생성
+const buildKSTDate = (baseDate, hhmm) => {
+  const yyyyMmDd = baseDate.toISOString().slice(0, 10); // YYYY-MM-DD (UTC기준이지만 아래 +09:00로 보정)
+  return new Date(`${yyyyMmDd}T${hhmm}:00+09:00`);
+};
+
 const toKSTISOString = (date) => {
   const offset = date.getTimezoneOffset() * 60000;
   return new Date(date.getTime() - offset).toISOString().slice(0, 19);
@@ -56,11 +66,45 @@ const ReservationComponent = ({ index, roomId }) => {
   };
 
   const getStatus = (time) => {
-    if (time.endsWith('23:59:00')) return 'display-only';
-    const timeDate = new Date(time);
-    if (timeDate < now) return 'past';
-    if (reservedTimeSlots.includes(time)) return 'reserved';
-    return 'available';
+    // (수정) 기준 날짜 및 KST 비교 기반 상태 판별
+    const baseDate = new Date(); // ReservationComponent는 '오늘' 기준
+    const timeStr = new Date(time).toTimeString().slice(0, 5); // HH:MM 포맷
+    const slotStart = buildKSTDate(baseDate, timeStr); // 예: "23:50"
+    // 10분 단위 슬롯이라면 종료를 +10분으로, 아니라면 23:59 같은 명시적 종료 사용
+    const slotEnd =
+      timeStr === '23:59'
+        ? buildKSTDate(baseDate, '23:59')
+        : new Date(slotStart.getTime() + 10 * 60 * 1000);
+
+    const now = nowInKST();
+    const isPast = slotEnd.getTime() < now.getTime(); // 엄격 부등호 사용
+
+    const isReserved = reservedTimeSlots.includes(time);
+
+    // 상태 우선순위: 과거 > 예약됨 > 예약가능 (과거 시간은 예약 여부 무시하고 모두 검은색)
+    let status;
+    if (isPast) {
+      status = 'past'; // 검은색
+    } else if (isReserved) {
+      status = 'reserved'; // 회색
+    } else {
+      status = 'available'; // 파란색
+    }
+
+    console.debug(
+      '[ReservationComponent] timeStr:',
+      timeStr,
+      'slotEnd(KST)=',
+      slotEnd.toISOString(),
+      'now(KST)=',
+      now.toISOString(),
+      'isPast=',
+      isPast,
+      'status=',
+      status,
+    );
+
+    return status;
   };
 
   const handleOpenModal = () => {

--- a/src/components/common/ReservationComponent.jsx
+++ b/src/components/common/ReservationComponent.jsx
@@ -15,7 +15,7 @@ const nowInKST = () =>
 
 // 기준 날짜(baseDate)와 HH:MM로 KST Date 생성
 const buildKSTDate = (baseDate, hhmm) => {
-  const yyyyMmDd = baseDate.toISOString().slice(0, 10); // YYYY-MM-DD (UTC기준이지만 아래 +09:00로 보정)
+  const yyyyMmDd = baseDate.toISOString().slice(0, 10);
   return new Date(`${yyyyMmDd}T${hhmm}:00+09:00`);
 };
 
@@ -67,28 +67,27 @@ const ReservationComponent = ({ index, roomId }) => {
 
   const getStatus = (time) => {
     // (수정) 기준 날짜 및 KST 비교 기반 상태 판별
-    const baseDate = new Date(); // ReservationComponent는 '오늘' 기준
-    const timeStr = new Date(time).toTimeString().slice(0, 5); // HH:MM 포맷
-    const slotStart = buildKSTDate(baseDate, timeStr); // 예: "23:50"
-    // 10분 단위 슬롯이라면 종료를 +10분으로, 아니라면 23:59 같은 명시적 종료 사용
+    const baseDate = new Date();
+    const timeStr = new Date(time).toTimeString().slice(0, 5);
+    const slotStart = buildKSTDate(baseDate, timeStr);
     const slotEnd =
       timeStr === '23:59'
         ? buildKSTDate(baseDate, '23:59')
         : new Date(slotStart.getTime() + 10 * 60 * 1000);
 
     const now = nowInKST();
-    const isPast = slotEnd.getTime() < now.getTime(); // 엄격 부등호 사용
+    const isPast = slotEnd.getTime() < now.getTime();
 
     const isReserved = reservedTimeSlots.includes(time);
 
     // 상태 우선순위: 과거 > 예약됨 > 예약가능 (과거 시간은 예약 여부 무시하고 모두 검은색)
     let status;
     if (isPast) {
-      status = 'past'; // 검은색
+      status = 'past';
     } else if (isReserved) {
-      status = 'reserved'; // 회색
+      status = 'reserved';
     } else {
-      status = 'available'; // 파란색
+      status = 'available';
     }
 
     console.debug(

--- a/src/components/common/ReservationHistory.jsx
+++ b/src/components/common/ReservationHistory.jsx
@@ -1,4 +1,4 @@
-const ReservationHistory = ({ reservation }) => {
+const ReservationHistory = ({ reservation, onCancel }) => {
   const startRaw = reservation.startTime || reservation.reservationStartTime;
   const endRaw = reservation.endTime || reservation.reservationEndTime;
 
@@ -18,6 +18,9 @@ const ReservationHistory = ({ reservation }) => {
       ? `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`
       : '--:--';
 
+  const now = new Date();
+  const canCancel = end && end.getTime() > now.getTime();
+
   return (
     <div className="flex items-center p-6 bg-[#FFFF] mt-2 gap-[10px]">
       <img
@@ -25,12 +28,20 @@ const ReservationHistory = ({ reservation }) => {
         alt="studyroom"
         className="w-[80px] h-[80px] object-cover rounded-md"
       />
-      <div className="flex flex-col justify-center">
+      <div className="flex flex-col justify-center flex-1">
         <div className="text-2xl">{`스터디룸 ${reservation.roomName}`}</div>
         <div className="text-[#788DFF]">
           {`${formatTime(start)} ~ ${formatTime(end)}`}
         </div>
       </div>
+      {canCancel && onCancel && (
+        <button
+          className="px-4 py-2 text-sm font-medium text-[#788DFF] hover:bg-[#788DFF] hover:text-white rounded-md transition-colors border border-[#788DFF]"
+          onClick={() => onCancel(reservation)}
+        >
+          취소
+        </button>
+      )}
     </div>
   );
 };

--- a/src/components/common/ReservationList.jsx
+++ b/src/components/common/ReservationList.jsx
@@ -3,8 +3,10 @@
 import { useEffect, useState } from 'react';
 import axiosInstance from '../../libs/api/instance';
 import useTokenStore from '../../stores/useTokenStore';
+import useReservationStore from '../../stores/useReservationStore';
 import MyPageDate from './MyPageDate';
 import ReservationHistory from './ReservationHistory';
+import CancellationModal from './CancellationModal';
 
 const groupByDate = (reservations) => {
   const grouped = {};
@@ -41,8 +43,10 @@ const groupByDate = (reservations) => {
 
 const ReservationList = () => {
   const { userId } = useTokenStore();
+  const { fetchAllReservedTimes } = useReservationStore();
   const [groupedReservations, setGroupedReservations] = useState({});
   const [loading, setLoading] = useState(true);
+  const [cancelModalData, setCancelModalData] = useState(null);
 
   useEffect(() => {
     if (!userId) {
@@ -74,6 +78,66 @@ const ReservationList = () => {
     fetchReservations();
   }, [userId]);
 
+  const handleCancelReservation = (reservation) => {
+    setCancelModalData(reservation);
+  };
+
+  const confirmCancelReservation = async () => {
+    if (!cancelModalData) return;
+
+    try {
+      const res = await axiosInstance.post('/api/reservations/cancel', {
+        userId,
+        reservationId: cancelModalData.id,
+      });
+      alert(res.data.message || '예약이 취소되었습니다.');
+      setCancelModalData(null);
+
+      const res2 = await axiosInstance.get(`/api/reservations/user/${userId}`);
+      const active = res2.data.reservations
+        .filter((r) => r.status === 'RESERVED')
+        .sort((a, b) => {
+          const getTime = (raw) =>
+            Array.isArray(raw) ? new Date(...raw) : new Date(raw);
+          return getTime(b.startTime) - getTime(a.startTime);
+        });
+      const grouped = groupByDate(active);
+      setGroupedReservations(grouped);
+
+      if (fetchAllReservedTimes) {
+        await fetchAllReservedTimes();
+      }
+    } catch (err) {
+      console.error('예약 취소 실패:', err);
+      alert(err.response?.data?.message || '예약 취소에 실패했습니다.');
+    }
+  };
+
+  const formatDate = (input) => {
+    let date;
+    if (Array.isArray(input)) {
+      const [year, month, day] = input;
+      date = new Date(year, month - 1, day);
+    } else {
+      date = input ? new Date(input) : null;
+    }
+    return date ? `${date.getMonth() + 1}월 ${date.getDate()}일` : '--월 --일';
+  };
+
+  const formatTime = (input) => {
+    let date;
+    if (Array.isArray(input)) {
+      const [year, month, day, hour = 0, minute = 0] = input;
+      date = new Date(year, month - 1, day, hour, minute);
+    } else {
+      date = input ? new Date(input) : null;
+    }
+    if (!date) return '--:--';
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    return `${hours}:${minutes}`;
+  };
+
   if (loading) return <div className="p-6">로딩 중...</div>;
 
   return (
@@ -87,10 +151,40 @@ const ReservationList = () => {
               <ReservationHistory
                 key={reservation.id}
                 reservation={reservation}
+                onCancel={handleCancelReservation}
               />
             ))}
           </div>
         ))}
+
+      {cancelModalData && (
+        <CancellationModal
+          isOpen={true}
+          onClose={() => setCancelModalData(null)}
+          onConfirm={confirmCancelReservation}
+        >
+          <div className="text-lg font-semibold text-left mb-6 text-[#37352f]">
+            예약을 취소할까요?
+          </div>
+          <div className="flex items-center gap-4 bg-[#f8f9ff] p-4 rounded-xl border border-gray-100">
+            <img
+              src="/static/icons/studyroom_image.png"
+              alt="studyroom"
+              className="w-20 h-20 object-cover rounded-lg"
+            />
+            <div className="flex flex-col gap-1 text-sm">
+              <div className="font-semibold text-[#37352f]">{`스터디룸 ${cancelModalData.roomName}`}</div>
+              <div className="text-[#73726e]">
+                {formatDate(cancelModalData.startTime)}
+              </div>
+              <div className="text-[#73726e]">
+                {formatTime(cancelModalData.startTime)} ~{' '}
+                {formatTime(cancelModalData.endTime)}
+              </div>
+            </div>
+          </div>
+        </CancellationModal>
+      )}
     </div>
   );
 };

--- a/src/components/common/TimeComponent.jsx
+++ b/src/components/common/TimeComponent.jsx
@@ -5,6 +5,8 @@ const TimeComponent = ({ status }) => {
         return '#9999A3';
       case 'past':
         return '#000000';
+      case 'display-only':
+        return '#CCCCCC';
       case 'available':
       default:
         return '#788DFF';

--- a/src/components/common/TomorrowReservationComponent.jsx
+++ b/src/components/common/TomorrowReservationComponent.jsx
@@ -259,6 +259,20 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
         </Modal>
       </div>
       <div className="mt-4 flex flex-col w-full">{renderTimeBlocks()}</div>
+      <div className="mt-3 flex items-center gap-4 text-xs text-gray-600">
+        <div className="flex items-center gap-1">
+          <div className="w-2 h-2 bg-[#788DFF]"></div>
+          <span>예약 가능</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="w-2 h-2 bg-[#9999A3]"></div>
+          <span>예약됨</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="w-2 h-2 bg-[#000000]"></div>
+          <span>지난 시간</span>
+        </div>
+      </div>
       <div className="bg-[#9999A3] h-0.5 w-full mt-3" />
       <LoginRequiredModal
         isOpen={showLoginModal}

--- a/src/components/common/TomorrowReservationComponent.jsx
+++ b/src/components/common/TomorrowReservationComponent.jsx
@@ -75,39 +75,22 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
   const getStatus = (time) => {
     if (time.endsWith('23:59:00')) return 'display-only';
 
-    // (수정) 기준 날짜 및 KST 비교 기반 상태 판별
-    const baseDate = new Date();
-    const timeStr = new Date(time).toTimeString().slice(0, 5);
-    const slotStart = buildKSTDate(baseDate, timeStr);
-    const slotEnd =
-      timeStr === '23:59'
-        ? buildKSTDate(baseDate, '23:59')
-        : new Date(slotStart.getTime() + 10 * 60 * 1000);
-
-    const now = nowInKST();
-    const isPast = slotEnd.getTime() < now.getTime();
-
+    // 내일 예약에서는 모든 시간이 미래시간이므로 예약된 시간만 회색으로 표시
     const isReserved = reservedTimeSlots.includes(time);
 
-    // 상태 우선순위: 과거 > 예약됨 > 예약가능 (과거 시간은 예약 여부 무시하고 모두 검은색)
     let status;
-    if (isPast) {
-      status = 'past';
-    } else if (isReserved) {
+    if (isReserved) {
       status = 'reserved';
     } else {
       status = 'available';
     }
 
+    const timeStr = new Date(time).toTimeString().slice(0, 5);
     console.debug(
       '[TomorrowReservationComponent] timeStr:',
       timeStr,
-      'slotEnd(KST)=',
-      slotEnd.toISOString(),
-      'now(KST)=',
-      now.toISOString(),
-      'isPast=',
-      isPast,
+      'isReserved=',
+      isReserved,
       'status=',
       status,
     );

--- a/src/components/common/TomorrowReservationComponent.jsx
+++ b/src/components/common/TomorrowReservationComponent.jsx
@@ -15,7 +15,7 @@ const nowInKST = () =>
 
 // 기준 날짜(baseDate)와 HH:MM로 KST Date 생성
 const buildKSTDate = (baseDate, hhmm) => {
-  const yyyyMmDd = baseDate.toISOString().slice(0, 10); // YYYY-MM-DD (UTC기준이지만 아래 +09:00로 보정)
+  const yyyyMmDd = baseDate.toISOString().slice(0, 10);
   return new Date(`${yyyyMmDd}T${hhmm}:00+09:00`);
 };
 
@@ -74,31 +74,29 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
 
   const getStatus = (time) => {
     if (time.endsWith('23:59:00')) return 'display-only';
-    
+
     // (수정) 기준 날짜 및 KST 비교 기반 상태 판별
-    const baseDate = new Date(); // TomorrowReservationComponent는 '내일' 기준
-    baseDate.setDate(baseDate.getDate() + 1);
-    const timeStr = new Date(time).toTimeString().slice(0, 5); // HH:MM 포맷
+    const baseDate = new Date();
+    const timeStr = new Date(time).toTimeString().slice(0, 5);
     const slotStart = buildKSTDate(baseDate, timeStr);
-    // 10분 단위 슬롯이라면 종료를 +10분으로, 아니라면 23:59 같은 명시적 종료 사용
     const slotEnd =
       timeStr === '23:59'
         ? buildKSTDate(baseDate, '23:59')
         : new Date(slotStart.getTime() + 10 * 60 * 1000);
 
     const now = nowInKST();
-    const isPast = slotEnd.getTime() < now.getTime(); // 엄격 부등호 사용
+    const isPast = slotEnd.getTime() < now.getTime();
 
     const isReserved = reservedTimeSlots.includes(time);
 
     // 상태 우선순위: 과거 > 예약됨 > 예약가능 (과거 시간은 예약 여부 무시하고 모두 검은색)
     let status;
     if (isPast) {
-      status = 'past'; // 검은색
+      status = 'past';
     } else if (isReserved) {
-      status = 'reserved'; // 회색
+      status = 'reserved';
     } else {
-      status = 'available'; // 파란색
+      status = 'available';
     }
 
     console.debug(

--- a/src/stores/useReservationStore.js
+++ b/src/stores/useReservationStore.js
@@ -47,9 +47,8 @@ const useReservationStore = create((set) => ({
       const nowKST = new Date();
 
       const filtered = res.data.reservations.filter((r) => {
-        const raw = r.startTime || r.reservationStartTime;
-        const start = parseToDate(raw);
-        return r.status === 'RESERVED' && start > nowKST;
+        const endTime = parseToDate(r.endTime);
+        return r.status === 'RESERVED' && endTime > nowKST;
       });
 
       const sorted = filtered.sort(


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/timecomponent-color-label-bug

### 💡 작업개요
문제
- `ReservationComponent`에서 23:59가 미래임에도 과거(검정색)로 표시되는 불일치 발생
- 과거 시간이면서 예약된 슬롯이 회색(예약됨)으로 남아 사용자 혼동 유발
- TimeComponent 색상 의미를 UI에서 설명하지 않아 가독성/이해도 저하

목표
- KST(Asia/Seoul) 기준으로 `slotEnd < now(KST)`이면 예약 여부와 무관하게 모두 검정색(past) 으로 일원화
- 두 컴포넌트에 색상 안내 문구(legend) 추가
- 23:59 슬롯의 표시 일관성 확보(표시 전용 `display-only` 처리 & 비교 엄격 부등호 적용)

### 🔑 주요 변경사항 
### 1) 시간 상태 판별 규칙의 KST 기준 일원화
- `nowInKST()`와 `buildKSTDate(baseDate, HH:MM)` 헬퍼를 도입/사용하여 브라우저 로컬 타임 혼입을 배제하고, 모든 비교를 Asia/Seoul(KST) 기준으로 수행
- 각 슬롯의 종료시각 `slotEnd`을 생성한 뒤 `slotEnd.getTime() < now.getTime()`(엄격 부등호 `<`) 로 과거 여부를 판정
- 동시각(`==`)은 과거로 간주하지 않음 → 23:59가 도달 전에는 미래 슬롯로 유지
- `baseDate`는 오늘/내일 맥락에 맞춰 사용(오늘: Reservation, 내일: Tomorrow)

### 2) 상태 우선순위 재정의 및 과거 일괄 처리
- 상태 결정 우선순위를 `과거 > 예약됨 > 예약가능`으로 재정렬.
- 과거 시간(`slotEnd < now(KST)`)은 예약 여부와 무관하게 항상 `past`(검정색)로 강제 일원화
- 예약 여부(`reservedTimeSlots`)는 과거 판정을 통과하지 않은 경우에만 평가 → 미래 슬롯에서만 `reserved`/`available` 분기

### 3) 23:59 특수 슬롯 처리 보강
- 10분 단위 슬롯 체계 외의 표시 전용 타일을 명확히 구분하기 위해 `display-only` 상태를 유지/활용
- 23:59는 상황에 따라 다음을 보장:
  - 현재 < 23:59(KST): 미래 → `available`/`reserved`(또는 표시 전용 분기 적용 시 `display-only`)
  - 현재 ≥ 23:59(KST): 즉시 `past`(검정색)로 전환
- 비교식의 엄격 부등호 `<` 채택으로 경계시각 처리 오동작(조기 `past` 판정) 방지

### 4) 색상 매핑 단일화(싱글 소스) 및 상태 명세 명확화
- `TimeComponent`에서 상태→색상 매핑을 단일화하여 UI 일관성 확보:
  - `available` → `#788DFF`(파란색)
  - `reserved` → `#9999A3`(회색)
  - `past` → `#000000`(검정)
  - `display-only` → `#CCCCCC`(표시 전용)
- 로직 측면에서는 상태 문자열이 오직 한 곳에서 최종 색상으로 해석되도록 상태 결정 ↔ 렌더 색상 매핑을 분리

### 5) 색상 안내 문구(legend) 추가로 상태 가시성 개선
- 타임라인 하단에 작은 텍스트 기반 legend 추가:
  - 파란색=예약 가능 / 회색=예약됨 / 검은색=지난 시간
- 기존 레이아웃·기능을 변경하지 않고 보조 정보만 추가(스타일/간격은 현행 유지)

### 6) 디버깅/검증을 위한 로깅 추가(임시)
- 상태 계산 지점에 `console.debug`로 `timeStr`, `slotEnd(KST)`, `now(KST)`, `isPast`, `status`를 출력해 경계 케이스(예: 23:59) 검증 용이
- 기능 확정 후 제거 가능(런타임·콘솔 노이즈 최소화 차원)

### 7) 성능·영향 범위
- 상태 계산은 슬롯당 O(1) 연산이며 전체는 슬롯 수에 선형(O(n))
- 기존 10초 폴링(`fetchAllReservedTimes`) 주기 및 API 연동, 스토어 구조 변경 없음
- 서버 스키마/응답 포맷 변경 없음 → 백엔드/계약 영향 없음
- 변경 위험은 클라이언트 시간 처리 로직(KST 강제) 영역으로 국한되며, 타 컴포넌트/페이지로의 회귀 리스크 낮음

### 8) AfterLoginBanner 및 useReservationStore에서 과거 예약 필터링 로직 추가
- `AfterLoginBanner`에서 예약 표시 기준을 `startTime` → `endTime`으로 변경하여 예약 종료 시간을 기준으로 필터링하도록 수정
- `endTime > nowKST` 조건을 적용해 현재 시각 이후에 종료되는 예약만 표시
- `useReservationStore`에서 동일한 과거 예약 필터링 로직을 추가하여 내일 예약 생성 시에도 종료된 예약이 다시 나타나지 않도록 처리
- 예시: 8월 12일 21:00~22:00 예약은 22:00가 지나야 `AfterLoginBanner`에서 사라짐

### 🏞 스크린샷
<img width="335" height="718" alt="image" src="https://github.com/user-attachments/assets/966f48a2-24fc-417a-badb-33d428b6e94f" />


### 🔗 관련 이슈 
- #98 