### PR TITLE
[Fix] 로그인 팝업 무한 렌더링 제거

### DIFF
--- a/src/app/my/account-info/page.jsx
+++ b/src/app/my/account-info/page.jsx
@@ -66,7 +66,8 @@ export default function AccountInfo() {
     <div className="min-h-screen bg-gray-50">
       <MyPageHeader />
 
-      <div className="px-6 py-6">
+      {!showLoginModal && (
+        <div className="px-6 py-6">
         <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden mb-6">
           <div className="px-6 py-5 border-b border-gray-100">
             <h2 className="text-lg font-semibold text-[#37352f]">내 정보</h2>
@@ -118,6 +119,7 @@ export default function AccountInfo() {
           <MyPageBlock name="회원 탈퇴" linkPath="/my/cancel-account-step1" />
         </div>
       </div>
+      )}
 
       <Modal
         isOpen={open}

--- a/src/app/my/cancel-account-step1/page.jsx
+++ b/src/app/my/cancel-account-step1/page.jsx
@@ -106,6 +106,7 @@ export default function CancelAccountStep1() {
     <>
       <div className="w-full">
         <MyPageHeader />
+        {!showLoginModal && (
         <div className="p-6 bg-[#FFFF] mt-6">
           <label className="mb-2 block">계정 이메일</label>
           <div className="flex gap-2">
@@ -171,6 +172,7 @@ export default function CancelAccountStep1() {
             </div>
           </Modal>
         </div>
+        )}
       </div>
 
       <LoginRequiredModal

--- a/src/app/my/reservation-list/page.jsx
+++ b/src/app/my/reservation-list/page.jsx
@@ -24,7 +24,7 @@ export default function ReservationInfo() {
   return (
     <div className="w-full">
       <MyPageHeader />
-      <ReservationList />
+      {!showLoginModal && <ReservationList />}
 
       <LoginRequiredModal
         isOpen={showLoginModal}

--- a/src/components/common/ReservationList.jsx
+++ b/src/components/common/ReservationList.jsx
@@ -42,14 +42,14 @@ const groupByDate = (reservations) => {
 };
 
 const ReservationList = () => {
-  const { userId } = useTokenStore();
+  const { userId, accessToken } = useTokenStore();
   const { fetchAllReservedTimes } = useReservationStore();
   const [groupedReservations, setGroupedReservations] = useState({});
   const [loading, setLoading] = useState(true);
   const [cancelModalData, setCancelModalData] = useState(null);
 
   useEffect(() => {
-    if (!userId) {
+    if (!userId || !accessToken) {
       setLoading(false);
       return;
     }
@@ -76,7 +76,7 @@ const ReservationList = () => {
     };
 
     fetchReservations();
-  }, [userId]);
+  }, [userId, accessToken]);
 
   const handleCancelReservation = (reservation) => {
     setCancelModalData(reservation);

--- a/src/libs/api/instance.js
+++ b/src/libs/api/instance.js
@@ -42,8 +42,8 @@ axiosInstance.interceptors.response.use(
     const { response } = error;
     if (response && (response.status === 401 || response.status === 403)) {
       if (typeof window !== 'undefined') {
-        alert('로그인이 필요합니다. 로그인 페이지로 이동합니다.');
-        // window.location.href = '/login';
+        // 로그인이 필요한 경우 토큰 제거
+        sessionStorage.removeItem('accessToken');
       }
     }
     return Promise.reject(error);


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/timecomponent-color-label-bug

### 💡 작업개요
- 증상: 보호 페이지 접근 시 ‘로그인이 필요합니다’ 팝업 노출 후 ‘확인’을 눌러도 팝업/페이지가 반복 렌더링되는 현상
- 주요 원인:
-- 인터셉터 alert로 인한 추가 렌더 트리거 및 사용자 흐름 방해
-- 비로그인 상태에서도 데이터 fetch 시도 → 401 재발 → 모달 재오픈
-- 모달이 떠 있는 동안에도 페이지 콘텐츠 렌더링 → 가드 useEffect 재동작/의존성 변동으로 루프 유발
- 해결 전략:
-- 인터셉터에서는 알림/라우팅을 하지 않고 토큰 정리만 수행(부작용 제거)
-- 컴포넌트 단에서 비로그인 시 API 호출 자체를 차단
-- 모달 표시 중에는 페이지/리스트를 렌더링하지 않음(언마운트로 트리거 차단)

### 🔑 주요 변경사항 
1. 401 응답 처리 개선
- API 인터셉터에서 `alert` 호출 제거
- 인증 만료 시 토큰 및 사용자 상태만 정리하고, 네비게이션/알림은 페이지 레벨에서 처리하도록 역할 분리

2. 비로그인 상태 API 호출 차단
- 토큰이 없을 경우 데이터 fetch 자체를 수행하지 않도록 조건 추가
- 불필요한 401 응답 및 재요청 방지

3. 렌더링 조건 제어를 통한 무한 루프 차단
- 로그인 모달이 표시되는 동안 페이지 콘텐츠 및 주요 컴포넌트 렌더링을 중단
- 모달 확인 시 즉시 로그인 페이지로 리다이렉트하여 useEffect 재트리거 방지

4. 효율적인 상태 변화 감지
- `useEffect` 의존성 배열 최적화로 불필요한 재호출 제거
- 상태 변화 시 필요한 최소 범위에서만 데이터 로딩 수행

### 🏞 스크린샷


### 🔗 관련 이슈 
- #105