### PR TITLE
[Feat] 로그인 유지 기능 추가 및 오류 메시지/비밀번호 안내 문구 개선

### DIFF
--- a/src/app/admin/login/page.jsx
+++ b/src/app/admin/login/page.jsx
@@ -1,6 +1,5 @@
 'use client';
 import React, { useState } from 'react';
-import axios from 'axios';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import Button from '../../../components/common/Button';
@@ -8,6 +7,7 @@ import { isValidPassword, strictEmailRegex } from '../../../constants/regex';
 import useTokenStore from '../../../stores/useTokenStore';
 import axiosInstance, { setAccessToken } from '../../../libs/api/instance';
 import { jwtDecode } from 'jwt-decode';
+import { getLoginErrorMessage } from '../../../utils/errorMessages';
 
 export default function AdminLogin() {
   const [email, setEmail] = useState('');
@@ -74,9 +74,7 @@ export default function AdminLogin() {
       }
     } catch (e) {
       console.error('로그인 실패:', e);
-      setConfirmError(
-        e?.response?.data?.message || '서버와 통신 중 오류가 발생했습니다.',
-      );
+      setConfirmError(getLoginErrorMessage(e));
     }
   };
 

--- a/src/app/login/page.jsx
+++ b/src/app/login/page.jsx
@@ -1,6 +1,5 @@
 'use client';
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import Button from '../../components/common/Button';
@@ -8,6 +7,7 @@ import { isValidPassword, strictEmailRegex } from '../../constants/regex';
 import useTokenStore from '../../stores/useTokenStore';
 import axiosInstance, { setAccessToken } from '../../libs/api/instance';
 import { jwtDecode } from 'jwt-decode';
+import { getLoginErrorMessage } from '../../utils/errorMessages';
 
 export default function Login() {
   const [email, setEmail] = useState('');
@@ -78,9 +78,7 @@ export default function Login() {
       }
     } catch (e) {
       console.error('로그인 실패:', e);
-      setConfirmError(
-        e?.response?.data?.message || '서버와 통신 중 오류가 발생했습니다.',
-      );
+      setConfirmError(getLoginErrorMessage(e));
     }
   };
 

--- a/src/app/login/page.jsx
+++ b/src/app/login/page.jsx
@@ -139,7 +139,7 @@ export default function Login() {
                 setPassword(pw);
                 if (!isValidPassword(pw)) {
                   setPasswordError(
-                    '비밀번호는 8자 이상, 영문과 숫자를 포함해야 합니다.',
+                    '비밀번호는 8자 이상, 영문과 숫자, 특수문자를 포함해야합니다.',
                   );
                 } else {
                   setPasswordError('');

--- a/src/app/login/page.jsx
+++ b/src/app/login/page.jsx
@@ -31,10 +31,35 @@ export default function Login() {
     if (redirect) {
       setRedirectUrl(decodeURIComponent(redirect));
     }
+
+    // 저장된 로그인 정보 불러오기
+    const savedLoginData = localStorage.getItem('savedLoginData');
+    if (savedLoginData) {
+      try {
+        const {
+          email: savedEmail,
+          password: savedPassword,
+          isLoginSave: savedIsLoginSave,
+        } = JSON.parse(savedLoginData);
+        if (savedIsLoginSave) {
+          setEmail(savedEmail || '');
+          setPassword(savedPassword || '');
+          setIsLoginSave(true);
+        }
+      } catch (error) {
+        console.error('저장된 로그인 정보를 불러오는 중 오류 발생:', error);
+      }
+    }
   }, [searchParams]);
 
   const handleLoginSave = () => {
-    setIsLoginSave(!isLoginSave);
+    const newIsLoginSave = !isLoginSave;
+    setIsLoginSave(newIsLoginSave);
+
+    // 로그인 유지를 해제하면 저장된 정보 삭제
+    if (!newIsLoginSave) {
+      localStorage.removeItem('savedLoginData');
+    }
   };
 
   const handlePasswordVisible = () => {
@@ -67,6 +92,19 @@ export default function Login() {
         setRefreshToken(refreshToken || '');
         const decoded = jwtDecode(accessToken);
         console.log('토큰 디코드 결과:', decoded);
+
+        // 로그인 성공 시 로그인 유지 옵션에 따라 정보 저장/삭제
+        if (isLoginSave) {
+          const loginData = {
+            email,
+            password,
+            isLoginSave: true,
+          };
+          localStorage.setItem('savedLoginData', JSON.stringify(loginData));
+        } else {
+          localStorage.removeItem('savedLoginData');
+        }
+
         router.push(redirectUrl);
       } else {
         // 디버깅용 로그

--- a/src/app/login/reset-password-step2/page.jsx
+++ b/src/app/login/reset-password-step2/page.jsx
@@ -79,7 +79,7 @@ export default function ResetPassword2() {
                 setnewPassword(pw);
                 if (!isValidPassword(pw)) {
                   setPasswordError(
-                    '비밀번호는 8자 이상, 영문·숫자·특수문자를 모두 포함해야 합니다.',
+                    '비밀번호는 8자 이상, 영문과 숫자, 특수문자를 포함해야합니다.',
                   );
                 } else {
                   setPasswordError('');

--- a/src/app/login/sign-up-step2/page.jsx
+++ b/src/app/login/sign-up-step2/page.jsx
@@ -67,7 +67,7 @@ export default function Login() {
               setnewPassword(pw);
               if (!isValidPassword(pw)) {
                 setPasswordError(
-                  '비밀번호는 8자 이상, 영문·숫자·특수문자를 모두 포함해야 합니다.',
+                  '비밀번호는 8자 이상, 영문과 숫자, 특수문자를 포함해야합니다.',
                 );
               } else {
                 setPasswordError('');

--- a/src/utils/errorMessages.js
+++ b/src/utils/errorMessages.js
@@ -1,0 +1,51 @@
+export const getLoginErrorMessage = (error) => {
+  if (!error?.response) {
+    return '서버와의 통신 오류가 발생했습니다. 네트워크 연결을 확인해주세요.';
+  }
+
+  const { status, data } = error.response;
+  const serverMessage = data?.message || '';
+
+  switch (status) {
+    case 400:
+      if (
+        serverMessage.includes('password') ||
+        serverMessage.includes('비밀번호')
+      ) {
+        return '비밀번호가 올바르지 않습니다.';
+      }
+      if (serverMessage.includes('email') || serverMessage.includes('이메일')) {
+        return '존재하지 않는 이메일입니다.';
+      }
+      if (
+        serverMessage.includes('credential') ||
+        serverMessage.includes('인증')
+      ) {
+        return '이메일 또는 비밀번호가 올바르지 않습니다.';
+      }
+      return serverMessage || '입력 정보를 확인해주세요.';
+
+    case 401:
+      return '이메일 또는 비밀번호가 올바르지 않습니다.';
+
+    case 403:
+      return '로그인이 차단되었습니다. 관리자에게 문의하세요.';
+
+    case 404:
+      return '존재하지 않는 이메일입니다.';
+
+    case 429:
+      return '로그인 시도 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.';
+
+    case 500:
+    case 502:
+    case 503:
+    case 504:
+      return '서버에 일시적인 문제가 발생했습니다. 잠시 후 다시 시도해주세요.';
+
+    default:
+      return (
+        serverMessage || '로그인 중 오류가 발생했습니다. 다시 시도해주세요.'
+      );
+  }
+};


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/login-error-message-handling

### 💡 작업개요
- 로그인 오류 메시지를 상태 코드별로 구체화하여 사용자가 문제 원인을 명확히 인지할 수 있도록 개선  
- 로그인, 회원가입, 비밀번호 재설정 페이지의 비밀번호 조건 안내 문구를 통일하여 일관된 UX 제공  
- '로그인 유지' 기능을 구현하여 사용자가 편리하게 재로그인할 수 있도록 지원 


### 🔑 주요 변경사항 
1. **로그인 오류 메시지 개선**
   - `src/utils/errorMessages.js` 유틸리티 추가
     - 401: `"이메일 또는 비밀번호가 올바르지 않습니다."`
     - 404: `"존재하지 않는 이메일입니다."`
     - 400: 서버 메시지 기반 구체적 오류 처리
     - 네트워크 오류: `"서버와의 통신 오류가 발생했습니다. 네트워크 연결을 확인해주세요."`
   - 로그인 페이지(`src/app/login/page.jsx:82`)와 관리자 로그인 페이지(`src/app/admin/login/page.jsx:78`)에서 기존 일반 메시지를 `getLoginErrorMessage()` 호출로 대체
   - 불필요한 `axios` import 제거

2. **비밀번호 조건 안내 문구 일관성 수정**
   - 세 페이지의 안내 문구를 `"비밀번호는 8자 이상, 영문과 숫자, 특수문자를 포함해야합니다"`로 통일
     - 로그인 페이지: `src/app/login/page.jsx:142`
     - 회원가입 페이지: `src/app/login/sign-up-step2/page.jsx:70`
     - 비밀번호 재설정 페이지: `src/app/login/reset-password-step2/page.jsx:82`

3. **로그인 유지 기능 구현**
   - '로그인 유지' 체크 상태로 로그인 시 이메일·비밀번호·체크 상태를 `localStorage`에 저장
   - 페이지 재방문 시 저장된 정보 자동 입력
   - 체크박스 해제 시 저장 데이터 즉시 삭제
   - `localStorage` 데이터 오류 발생 시 예외 처리로 안전성 확보


### 🏞 스크린샷


### 🔗 관련 이슈 
- #70 #100