### PR TITLE
[Feat] 로그아웃 블록 추가 및 API 연동/토큰 정리/모달/리다이렉트 구현

### DIFF
--- a/src/app/my/account-info/page.jsx
+++ b/src/app/my/account-info/page.jsx
@@ -13,7 +13,8 @@ export default function AccountInfo() {
   const [open, setOpen] = useState(false);
   const [newName, setNewName] = useState('');
   const [showLoginModal, setShowLoginModal] = useState(false);
-  const { accessToken, userId } = useTokenStore();
+  const [showLogoutModal, setShowLogoutModal] = useState(false);
+  const { accessToken, userId, clearTokens } = useTokenStore();
 
   const getDecodedUserInfo = () => {
     try {
@@ -60,6 +61,22 @@ export default function AccountInfo() {
       console.error('이름 변경 실패:', error);
       alert('이름 변경에 실패했습니다.');
     }
+  };
+
+  const handleLogout = async () => {
+    try {
+      await axiosInstance.post('/auth/logout');
+    } catch (error) {
+      console.error('로그아웃 API 호출 실패:', error);
+    } finally {
+      clearTokens();
+      setShowLogoutModal(true);
+    }
+  };
+
+  const handleLogoutConfirm = () => {
+    setShowLogoutModal(false);
+    window.location.href = '/login';
   };
 
   return (
@@ -117,6 +134,17 @@ export default function AccountInfo() {
             linkPath="/login/reset-password-step1"
           />
           <MyPageBlock name="회원 탈퇴" linkPath="/my/cancel-account-step1" />
+          <button
+            className="w-full flex items-center justify-between px-6 py-4 hover:bg-gray-50 transition-colors border-t border-gray-100"
+            onClick={handleLogout}
+          >
+            <span className="text-base font-medium text-[#37352f]">로그아웃</span>
+            <img
+              src="/static/icons/arrow_right_icon.svg"
+              alt="arrow"
+              className="w-5 h-5 opacity-60"
+            />
+          </button>
         </div>
       </div>
       )}
@@ -150,6 +178,34 @@ export default function AccountInfo() {
         isOpen={showLoginModal} 
         onConfirm={handleLoginConfirm} 
       />
+
+      <div
+        className={`fixed inset-0 bg-black/50 flex justify-center items-center z-[9999] ${showLogoutModal ? '' : 'hidden'}`}
+        style={{ backdropFilter: 'blur(4px)' }}
+      >
+        <div
+          className="bg-white rounded-2xl w-[90%] max-w-md mx-4 shadow-2xl border border-gray-100 overflow-hidden"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="overflow-y-auto max-h-[70vh] p-6">
+            <div className="text-center">
+              <h3 className="text-lg font-medium text-gray-900 mb-4">알림</h3>
+              <p className="text-gray-600 text-sm leading-relaxed">
+                로그아웃이 완료되었습니다
+              </p>
+            </div>
+          </div>
+
+          <div className="flex border-t border-gray-100">
+            <button
+              onClick={handleLogoutConfirm}
+              className="w-full py-4 bg-[#788cff] text-white text-sm font-medium hover:bg-[#6a7dff] transition-colors"
+            >
+              확인
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/my-page-logout

### 💡 작업개요
- 마이페이지 account-info 화면에 로그아웃 기능 추가
- “개인정보 보호” 섹션 하단에 로그아웃 블록을 배치하고, 클릭 시 서버 로그아웃 요청 → 토큰/세션 정리 → 완료 모달 표출 → 확인 시 로그인 페이지로 이동하는 플로우 구현 
- API 실패 시에도 사용자의 보안을 위해 항상 로컬 토큰을 삭제하고 로그인 화면으로 이동하도록 finally 로직 적용


### 🔑 주요 변경사항 
### UI 추가
- “개인정보 보호” 섹션 하단에 **로그아웃 블록** 추가  
  - 위치: `src/app/my/account-info/page.jsx:120-130`  
  - 기존 디자인과 톤을 맞춰 접근성(버튼 포커스/탭 이동) 및 터치 영역 고려

### 로그아웃 동작 로직
- `handleLogout` 구현  
  - 서버 로그아웃: `POST /auth/logout`  
  - 토큰/세션 정리: `clearTokens()` 호출 및 관련 스토리지 값 제거  
  - 완료 모달 오픈 → 확인 클릭 시 `router.replace('/login')`  
- 위치:  
  - API/토큰 정리: `src/app/my/account-info/page.jsx:65-74, 73`  
  - 모달 제어/이동: `src/app/my/account-info/page.jsx:77-80, 182-208`

### 에러/네트워크 실패 대응
- `try/catch/finally` 구성으로 **성공 여부와 무관하게** 토큰 정리 및 화면 전환 보장  
- 예외 발생 시에도 UX 끊김 없이 완료 모달 → 로그인 이동

### 모달 표시
- 메시지: “로그아웃이 완료되었습니다”  
- 확인 클릭 시 로그인 페이지로 이동 (`router.replace('/login')`)  
- 중복 클릭 방지를 위한 로딩/비활성 상태 처리

### 보안/UX 보강
- `replace` 내비게이션 사용으로 뒤로가기로 인증 페이지로 복귀 방지  
- API 응답 지연/실패 시에도 로컬 세션 정리 우선 실행


### 🏞 스크린샷
<img width="334" height="719" alt="image" src="https://github.com/user-attachments/assets/2d42dc65-63be-425a-bbd8-d3db91188e58" />
<img width="331" height="717" alt="image" src="https://github.com/user-attachments/assets/c4c5ce44-40a9-421b-a308-446765deea00" />


### 🔗 관련 이슈 
- #89
