### PR TITLE
[Feat] 회원가입, 비밀번호 재설정 페이지 인증번호 전송 중 화면 오버레이 스피너 및 메일 발송 지연 안내 추가

### DIFF
--- a/src/app/login/reset-password-step1/page.jsx
+++ b/src/app/login/reset-password-step1/page.jsx
@@ -150,6 +150,26 @@ export default function ResetPassWord1() {
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col px-6 py-8">
+      {/* 스피너 오버레이 */}
+      {isSending && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center"
+          role="status"
+          aria-live="polite"
+        >
+          <div className="bg-white rounded-lg p-6 flex flex-col items-center space-y-4">
+            <div
+              className="w-8 h-8 border-4 border-[#788cff] border-t-transparent rounded-full animate-spin"
+              aria-label="로딩 중"
+            ></div>
+            <p className="text-sm text-gray-600 text-center">
+              메일을 전송 중이예요. 시스템 환경에 따라 딜레이가 발생할 수
+              있어요.
+            </p>
+          </div>
+        </div>
+      )}
+
       <div className="text-center space-y-3 mb-8">
         <h1 className="text-2xl font-bold text-[#37352f]">비밀번호 재설정</h1>
         <p className="text-[#73726e] text-sm">등록한 이메일로 찾기</p>
@@ -181,6 +201,7 @@ export default function ResetPassWord1() {
                   }}
                   placeholder="학교 이메일을 입력해주세요."
                   setEmail={setEmail}
+                  disabled={isSending}
                 />
               </div>
               <button
@@ -212,6 +233,7 @@ export default function ResetPassWord1() {
                   inputMode="numeric"
                   maxLength={6}
                   className="pr-14"
+                  disabled={isSending}
                 />
                 {codeSent && (
                   <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-[#666]">
@@ -228,7 +250,8 @@ export default function ResetPassWord1() {
                   isVerifying ||
                   !codeSent ||
                   secondsLeft <= 0 ||
-                  !/^[0-9]{6}$/.test(number)
+                  !/^[0-9]{6}$/.test(number) ||
+                  isSending
                 }
               >
                 {isVerifying ? '확인중' : '인증번호 확인'}
@@ -277,15 +300,15 @@ const StyledInput = ({ value, className = '', ...props }) => {
   );
 };
 
-const StyledEmailInput = ({ value, setEmail, ...props }) => {
+const StyledEmailInput = ({ value, setEmail, disabled, ...props }) => {
   const handleRemoveEmailValue = () => {
     setEmail('');
   };
 
   return (
     <div className="relative">
-      <StyledInput {...props} value={value} />
-      {value && (
+      <StyledInput {...props} value={value} disabled={disabled} />
+      {value && !disabled && (
         <button
           type="button"
           onClick={handleRemoveEmailValue}

--- a/src/app/login/reset-password-step1/page.jsx
+++ b/src/app/login/reset-password-step1/page.jsx
@@ -157,7 +157,7 @@ export default function ResetPassWord1() {
           role="status"
           aria-live="polite"
         >
-          <div className="bg-white rounded-lg p-6 flex flex-col items-center space-y-4">
+          <div className="bg-white rounded-lg p-4 sm:p-6 flex flex-col items-center space-y-4 max-w-sm mx-4 sm:max-w-none sm:mx-0">
             <div
               className="w-8 h-8 border-4 border-[#788cff] border-t-transparent rounded-full animate-spin"
               aria-label="로딩 중"

--- a/src/app/login/sign-up-step1/page.jsx
+++ b/src/app/login/sign-up-step1/page.jsx
@@ -157,6 +157,26 @@ export default function SignUpStep1() {
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col px-6 py-8">
+      {/* 스피너 오버레이 */}
+      {isSending && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center"
+          role="status"
+          aria-live="polite"
+        >
+          <div className="bg-white rounded-lg p-6 flex flex-col items-center space-y-4">
+            <div
+              className="w-8 h-8 border-4 border-[#788cff] border-t-transparent rounded-full animate-spin"
+              aria-label="로딩 중"
+            ></div>
+            <p className="text-sm text-gray-600 text-center">
+              메일을 전송 중이예요. 시스템 환경에 따라 딜레이가 발생할 수
+              있어요.
+            </p>
+          </div>
+        </div>
+      )}
+
       <div className="text-center space-y-3 mb-8">
         <h1 className="text-2xl font-bold text-[#37352f]">회원가입</h1>
         <p className="text-[#73726e] text-sm">학교 이메일 인증하기</p>
@@ -188,6 +208,7 @@ export default function SignUpStep1() {
                 }}
                 placeholder="학교 이메일을 입력해주세요."
                 setEmail={setEmail}
+                disabled={isSending}
               />
             </div>
             <button
@@ -218,6 +239,7 @@ export default function SignUpStep1() {
                 inputMode="numeric"
                 maxLength={6}
                 className="pr-14"
+                disabled={isSending}
               />
               {codeSent && (
                 <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-[#666]">
@@ -228,7 +250,7 @@ export default function SignUpStep1() {
             <button
               className={commonCodeButtonClass}
               onClick={handleVerifyCode}
-              disabled={!canVerify || isVerifying}
+              disabled={!canVerify || isVerifying || isSending}
             >
               {isVerifying ? '확인중' : '인증번호 확인'}
             </button>
@@ -265,12 +287,23 @@ const StyledInput = ({ value, className = '', ...props }) => {
   return <input className={`${base} ${className}`} value={value} {...props} />;
 };
 
-const StyledEmailInput = ({ value, setEmail, className = '', ...props }) => {
+const StyledEmailInput = ({
+  value,
+  setEmail,
+  className = '',
+  disabled,
+  ...props
+}) => {
   const handleRemoveEmailValue = () => setEmail('');
   return (
     <div className="relative">
-      <StyledInput {...props} value={value} className={className} />
-      {value && (
+      <StyledInput
+        {...props}
+        value={value}
+        className={className}
+        disabled={disabled}
+      />
+      {value && !disabled && (
         <button
           type="button"
           onClick={handleRemoveEmailValue}

--- a/src/app/login/sign-up-step1/page.jsx
+++ b/src/app/login/sign-up-step1/page.jsx
@@ -164,7 +164,7 @@ export default function SignUpStep1() {
           role="status"
           aria-live="polite"
         >
-          <div className="bg-white rounded-lg p-6 flex flex-col items-center space-y-4">
+          <div className="bg-white rounded-lg p-4 sm:p-6 flex flex-col items-center space-y-4 max-w-sm mx-4 sm:max-w-none sm:mx-0">
             <div
               className="w-8 h-8 border-4 border-[#788cff] border-t-transparent rounded-full animate-spin"
               aria-label="로딩 중"


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/authcode-spinner-and-smtp-delay-notice

### 💡 작업개요
- 회원가입 1단계와 비밀번호 재설정 1단계에서 인증번호 전송이 지연되는 동안 사용자가 진행 상태를 명확히 인지할 수 있도록 전체 화면 스피너 오버레이와 메일 발송 지연 안내문구 추가
- 전송 중에는 모든 입력/버튼을 비활성화하여 중복 전송을 방지하고, 네트워크 오류/타임아웃 발생 시에도 오버레이가 반드시 해제되도록 finally 구문으로 상태 복구

### 🔑 주요 변경사항 
1. 상태 및 전송 흐름
- `isSending` 상태 추가: 전송 시작 시 `true`, `finally`에서 `false`
- 안전한 해제 보장: 예외 발생(에러/타임아웃) 상황에서도 `finally`로 오버레이 해제

2. 오버레이/스피너 UI
- 전체 화면 오버레이: `fixed inset-0 z-50 flex items-center justify-center bg-black/40`
- 스피너: CSS 기반 회전 애니메이션(`animate-spin`, `border-t-transparent`) 적용
- 접근성:
-- 컨테이너: `role="status" aria-live="polite"`
-- 스피너: `aria-label="인증 메일 전송 중"`
- 문구 고지: `"메일을 전송 중이예요. 시스템 환경에 따라 딜레이가 발생할 수 있어요."`

3. 입력/버튼 비활성화
- 전송 중 `disabled` 적용: 이메일 입력 필드, 인증번호 입력 필드, 인증번호 전송 버튼 및 관련 액션 버튼
- 중복 클릭/입력으로 인한 불필요한 요청 방지


### 🏞 스크린샷
<img width="333" height="717" alt="image" src="https://github.com/user-attachments/assets/4e4c62d1-07da-4315-a7f6-c1440ab72e2e" />

### 🔗 관련 이슈 
- #114
