### PR TITLE
[Fix] 로그인 리다이렉트 직후 마이페이지/예약내역 ‘없음’ 표시 문제 수정

### DIFF
--- a/src/app/login/page.jsx
+++ b/src/app/login/page.jsx
@@ -23,7 +23,7 @@ function LoginForm() {
   const searchParams = useSearchParams();
   const [redirectUrl, setRedirectUrl] = useState('/');
 
-  const { setAccessToken: setGlobalAccessToken, setRefreshToken } =
+  const { setAccessToken: setGlobalAccessToken, setRefreshToken, setUserId } =
     useTokenStore();
 
   useEffect(() => {
@@ -93,6 +93,12 @@ function LoginForm() {
         const decoded = jwtDecode(accessToken);
         console.log('토큰 디코드 결과:', decoded);
 
+        // userId를 토큰에서 추출하여 설정
+        const extractedUserId = decoded?.userId ?? decoded?.id ?? decoded?.uid ?? decoded?.sub ?? null;
+        if (extractedUserId) {
+          setUserId(extractedUserId);
+        }
+
         // 로그인 성공 시 로그인 유지 옵션에 따라 정보 저장/삭제
         if (isLoginSave) {
           const loginData = {
@@ -105,7 +111,10 @@ function LoginForm() {
           localStorage.removeItem('savedLoginData');
         }
 
-        router.push(redirectUrl);
+        // 토큰과 userId 설정이 완료된 후 리다이렉트
+        setTimeout(() => {
+          router.push(redirectUrl);
+        }, 50);
       } else {
         // 디버깅용 로그
         console.warn(

--- a/src/app/my/account-info/page.jsx
+++ b/src/app/my/account-info/page.jsx
@@ -15,13 +15,27 @@ export default function AccountInfo() {
   const [newName, setNewName] = useState('');
   const [showLoginModal, setShowLoginModal] = useState(false);
   const [showLogoutModal, setShowLogoutModal] = useState(false);
-  const { accessToken, userId, clearTokens } = useTokenStore();
+
+  const { accessToken, userId, clearTokens, rehydrate } = useTokenStore();
+
+  const [authReady, setAuthReady] = useState(false);
+
+  useEffect(() => {
+    rehydrate();
+    const t = setTimeout(() => setAuthReady(true), 0);
+    return () => clearTimeout(t);
+  }, [rehydrate]);
+
+  useEffect(() => {
+    if (!authReady) return;
+    setShowLoginModal(!accessToken);
+  }, [authReady, accessToken]);
 
   const getDecodedUserInfo = () => {
     try {
       const decoded = jwtDecode(accessToken);
-      const { email, username } = decoded;
-      return { name: username, email };
+      const { email, username } = decoded || {};
+      return { name: username || '', email: email || '' };
     } catch {
       return { name: '', email: '' };
     }
@@ -30,10 +44,9 @@ export default function AccountInfo() {
   const [userInfo, setUserInfo] = useState(getDecodedUserInfo);
 
   useEffect(() => {
-    if (!accessToken) {
-      setShowLoginModal(true);
-    }
-  }, [accessToken]);
+    if (!authReady) return;
+    setUserInfo(getDecodedUserInfo());
+  }, [authReady, accessToken]);
 
   const handleLoginConfirm = () => {
     const currentPath = window.location.pathname;
@@ -46,12 +59,10 @@ export default function AccountInfo() {
         alert('이름을 입력해주세요.');
         return;
       }
-
       const response = await axiosInstance.put('/user/change-username', {
         userId,
         newUsername: newName,
       });
-
       if (response.status === 200) {
         alert('이름 변경 완료되었습니다.');
         setUserInfo((prev) => ({ ...prev, name: newName }));
@@ -85,82 +96,92 @@ export default function AccountInfo() {
       <main className="flex-1">
         <MyPageHeader />
 
-        {!showLoginModal && (
-          <div className="px-6 py-6">
-            <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden mb-6">
-              <div className="px-6 py-5 border-b border-gray-100">
-                <h2 className="text-lg font-semibold text-[#37352f]">
-                  내 정보
-                </h2>
-              </div>
-
-              <div className="px-6 py-4 border-b border-gray-100">
-                <div className="space-y-1">
-                  <label className="text-sm font-medium text-[#37352f]">
-                    이메일
-                  </label>
-                  <p className="text-sm text-[#73726e]">
-                    {userInfo.email || '이메일 없음'}
-                  </p>
+        {/* authReady 전에는 '없음' 같은 빈 상태를 렌더하지 않음 */}
+        {!authReady ? (
+          <div className="px-6 py-6">로딩 중...</div>
+        ) : (
+          !showLoginModal && (
+            <div className="px-6 py-6">
+              {/* 내 정보 카드 */}
+              <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden mb-6">
+                <div className="px-6 py-5 border-b border-gray-100">
+                  <h2 className="text-lg font-semibold text-[#37352f]">
+                    내 정보
+                  </h2>
                 </div>
-              </div>
 
-              <button
-                className="w-full flex items-center justify-between px-6 py-4 hover:bg-gray-50 transition-colors"
-                onClick={() => setOpen(true)}
-              >
-                <div className="flex flex-col gap-1 text-left">
-                  <label className="text-sm font-medium text-[#37352f]">
-                    이름
-                  </label>
-                  <p className="text-sm text-[#73726e]">
-                    {userInfo.name || '이름 없음'}
-                  </p>
+                <div className="px-6 py-4 border-b border-gray-100">
+                  <div className="space-y-1">
+                    <label className="text-sm font-medium text-[#37352f]">
+                      이메일
+                    </label>
+                    <p className="text-sm text-[#73726e]">
+                      {userInfo.email || '이메일 없음'}
+                    </p>
+                  </div>
                 </div>
-                <img
-                  src="/static/icons/arrow_right_icon.svg"
-                  alt="arrow"
-                  className="w-5 h-5 opacity-60"
-                />
-              </button>
-            </div>
 
-            <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden mb-6">
-              <MyPageBlock name="예약 내역" linkPath="/my/reservation-list" />
-            </div>
-
-            <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
-              <div className="px-6 py-5 border-b border-gray-100">
-                <h2 className="text-lg font-semibold text-[#37352f]">
-                  개인정보 보호
-                </h2>
+                <button
+                  className="w-full flex items-center justify-between px-6 py-4 hover:bg-gray-50 transition-colors"
+                  onClick={() => setOpen(true)}
+                >
+                  <div className="flex flex-col gap-1 text-left">
+                    <label className="text-sm font-medium text-[#37352f]">
+                      이름
+                    </label>
+                    <p className="text-sm text-[#73726e]">
+                      {userInfo.name || '이름 없음'}
+                    </p>
+                  </div>
+                  <img
+                    src="/static/icons/arrow_right_icon.svg"
+                    alt="arrow"
+                    className="w-5 h-5 opacity-60"
+                  />
+                </button>
               </div>
-              <MyPageBlock
-                name="비밀번호 재설정"
-                linkPath="/login/reset-password-step1"
-              />
-              <MyPageBlock
-                name="회원 탈퇴"
-                linkPath="/my/cancel-account-step1"
-              />
-              <button
-                className="w-full flex items-center justify-between px-6 py-4 hover:bg-gray-50 transition-colors border-t border-gray-100"
-                onClick={handleLogout}
-              >
-                <span className="text-base font-medium text-[#37352f]">
-                  로그아웃
-                </span>
-                <img
-                  src="/static/icons/arrow_right_icon.svg"
-                  alt="arrow"
-                  className="w-5 h-5 opacity-60"
+
+              {/* 예약 내역 진입 */}
+              <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden mb-6">
+                <MyPageBlock name="예약 내역" linkPath="/my/reservation-list" />
+              </div>
+
+              {/* 개인정보 보호 섹션 */}
+              <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
+                <div className="px-6 py-5 border-b border-gray-100">
+                  <h2 className="text-lg font-semibold text-[#37352f]">
+                    개인정보 보호
+                  </h2>
+                </div>
+
+                <MyPageBlock
+                  name="비밀번호 재설정"
+                  linkPath="/login/reset-password-step1"
                 />
-              </button>
+                <MyPageBlock
+                  name="회원 탈퇴"
+                  linkPath="/my/cancel-account-step1"
+                />
+                <button
+                  className="w-full flex items-center justify-between px-6 py-4 hover:bg-gray-50 transition-colors border-t border-gray-100"
+                  onClick={handleLogout}
+                >
+                  <span className="text-base font-medium text-[#37352f]">
+                    로그아웃
+                  </span>
+                  <img
+                    src="/static/icons/arrow_right_icon.svg"
+                    alt="arrow"
+                    className="w-5 h-5 opacity-60"
+                  />
+                </button>
+              </div>
             </div>
-          </div>
+          )
         )}
       </main>
 
+      {/* 이름 변경 모달 */}
       <Modal
         isOpen={open}
         onClose={() => setOpen(false)}
@@ -186,14 +207,19 @@ export default function AccountInfo() {
         </div>
       </Modal>
 
+      {/* 로그인 요구 모달: authReady 이후에만 표시 */}
       <LoginRequiredModal
-        isOpen={showLoginModal}
+        isOpen={authReady && showLoginModal}
         onConfirm={handleLoginConfirm}
       />
 
+      {/* 로그아웃 완료 모달 */}
       <div
-        className={`fixed inset-0 bg-black/50 flex justify-center items-center z-[9999] ${showLogoutModal ? '' : 'hidden'}`}
+        className={`fixed inset-0 bg-black/50 flex justify-center items-center z-[9999] ${
+          showLogoutModal ? '' : 'hidden'
+        }`}
         style={{ backdropFilter: 'blur(4px)' }}
+        onClick={() => setShowLogoutModal(false)}
       >
         <div
           className="bg-white rounded-2xl w-[90%] max-w-md mx-4 shadow-2xl border border-gray-100 overflow-hidden"

--- a/src/app/my/reservation-list/page.jsx
+++ b/src/app/my/reservation-list/page.jsx
@@ -9,12 +9,15 @@ import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
 
 export default function ReservationInfo() {
   const [showLoginModal, setShowLoginModal] = useState(false);
-  const { accessToken } = useTokenStore();
+  const { accessToken, rehydrate } = useTokenStore();
 
   useEffect(() => {
-    if (!accessToken) {
-      setShowLoginModal(true);
-    }
+    rehydrate();
+  }, [rehydrate]);
+
+  // 토큰 유무에 따라 모달을 양방향으로 토글
+  useEffect(() => {
+    setShowLoginModal(!accessToken);
   }, [accessToken]);
 
   const handleLoginConfirm = () => {
@@ -26,7 +29,11 @@ export default function ReservationInfo() {
     <div className="min-h-screen bg-gray-50 flex flex-col">
       <main className="flex-1">
         <MyPageHeader />
-        {!showLoginModal && <ReservationList />}
+        {!showLoginModal && (
+          <ReservationList
+            /* key로 리마운트 보조 */ key={accessToken || 'guest'}
+          />
+        )}
       </main>
 
       <LoginRequiredModal

--- a/src/components/common/ReservationList.jsx
+++ b/src/components/common/ReservationList.jsx
@@ -1,112 +1,170 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import axiosInstance from '../../libs/api/instance';
 import useTokenStore from '../../stores/useTokenStore';
 import useReservationStore from '../../stores/useReservationStore';
 import MyPageDate from './MyPageDate';
 import ReservationHistory from './ReservationHistory';
 import CancellationModal from './CancellationModal';
+import jwtDecode from 'jwt-decode';
+
+const toDateFromRaw = (raw) => {
+  if (!raw) return null;
+  if (Array.isArray(raw)) {
+    const [y, m = 1, d = 1, hh = 0, mm = 0, ss = 0, ms = 0] = raw;
+    return new Date(y, m - 1, d, hh, mm, ss, ms);
+  }
+  const dt = new Date(raw);
+  return isNaN(dt) ? null : dt;
+};
+
+const norm = (v) =>
+  String(v ?? '')
+    .toUpperCase()
+    .trim();
+
+const isCanceled = (r) => {
+  const s = norm(r.status);
+  if (r.canceledAt || r.cancelledAt) return true;
+  if (s === 'CANCELLED' || s === 'CANCELED') return true;
+  return false;
+};
 
 const groupByDate = (reservations) => {
   const grouped = {};
-
   reservations.forEach((r) => {
-    const rawDate = r.startTime || r.reservationStartTime;
-
-    let date;
-    if (Array.isArray(rawDate)) {
-      const [year, month, day] = rawDate;
-      date = new Date(year, month - 1, day);
-    } else {
-      date = rawDate ? new Date(rawDate) : null;
-    }
-
-    if (!date || isNaN(date)) {
-      if (!grouped['Invalid Date']) grouped['Invalid Date'] = [];
-      grouped['Invalid Date'].push(r);
+    const start = toDateFromRaw(r.startTime ?? r.reservationStartTime);
+    if (!start) {
+      (grouped['Invalid Date'] ??= []).push(r);
       return;
     }
-
-    const dateStr = date.toLocaleDateString('ko-KR', {
+    const key = start.toLocaleDateString('ko-KR', {
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',
     });
-
-    if (!grouped[dateStr]) grouped[dateStr] = [];
-    grouped[dateStr].push(r);
+    (grouped[key] ??= []).push(r);
   });
-
   return grouped;
 };
 
-const ReservationList = () => {
-  const { userId, accessToken } = useTokenStore();
+export default function ReservationList() {
+  // rehydrate 추가로 세션→스토어 동기화
+  const { userId, accessToken, rehydrate } = useTokenStore();
   const { fetchAllReservedTimes } = useReservationStore();
+
   const [groupedReservations, setGroupedReservations] = useState({});
   const [loading, setLoading] = useState(true);
   const [cancelModalData, setCancelModalData] = useState(null);
+  const [authReady, setAuthReady] = useState(false); // ✅ 준비 플래그
 
+  // 첫 마운트 시 세션 값을 스토어로 강제 동기화
   useEffect(() => {
-    if (!userId || !accessToken) {
+    if (typeof rehydrate === 'function') {
+      rehydrate();
+    }
+    // 로그인 후 리다이렉트 시 토큰 동기화를 위해 더 긴 지연시간 설정
+    const t = setTimeout(() => setAuthReady(true), 100);
+    return () => clearTimeout(t);
+  }, [rehydrate]);
+
+  // userId 미존재 시 토큰에서 보조 추출
+  const resolvedUserId = useMemo(() => {
+    if (userId) return userId;
+    if (!accessToken) return null;
+    try {
+      const d = jwtDecode(accessToken);
+      return d?.userId ?? d?.id ?? d?.uid ?? d?.sub ?? null;
+    } catch {
+      return null;
+    }
+  }, [userId, accessToken]);
+
+  const sortByStartDesc = (a, b) => {
+    const aT =
+      toDateFromRaw(a.startTime ?? a.reservationStartTime)?.getTime() ?? 0;
+    const bT =
+      toDateFromRaw(b.startTime ?? b.reservationStartTime)?.getTime() ?? 0;
+    return bT - aT;
+  };
+
+  const buildGrouped = (reservations) => {
+    const visible = (reservations ?? [])
+      .filter((r) => !isCanceled(r))
+      .sort(sortByStartDesc);
+    return groupByDate(visible);
+  };
+
+  const fetchReservations = async (uid) => {
+    try {
+      setLoading(true);
+      // 캐시 우회 파라미터로 최초 빈 응답/재사용 방지
+      const res = await axiosInstance.get(
+        `/api/reservations/user/${uid}?t=${Date.now()}`,
+      );
+      setGroupedReservations(buildGrouped(res.data?.reservations));
+    } catch (err) {
+      console.error('예약 내역 불러오기 실패:', err);
+      setGroupedReservations({});
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // authReady 이후에만 판단/요청 실행
+  useEffect(() => {
+    if (!authReady) return;
+
+    if (!accessToken || !resolvedUserId) {
+      setGroupedReservations({});
       setLoading(false);
       return;
     }
 
-    const fetchReservations = async () => {
-      try {
-        const res = await axiosInstance.get(`/api/reservations/user/${userId}`);
+    const sessionToken =
+      typeof window !== 'undefined'
+        ? sessionStorage.getItem('accessToken')
+        : null;
+    if (!sessionToken) {
+      const retryTimeout = setTimeout(() => {
+        const retryToken =
+          typeof window !== 'undefined'
+            ? sessionStorage.getItem('accessToken')
+            : null;
+        if (retryToken && resolvedUserId) {
+          fetchReservations(resolvedUserId);
+        } else {
+          setGroupedReservations({});
+          setLoading(false);
+        }
+      }, 50);
+      return () => clearTimeout(retryTimeout);
+    }
 
-        const active = res.data.reservations
-          .filter((r) => r.status === 'RESERVED')
-          .sort((a, b) => {
-            const getTime = (raw) =>
-              Array.isArray(raw) ? new Date(...raw) : new Date(raw);
-            return getTime(b.startTime) - getTime(a.startTime);
-          });
-
-        const grouped = groupByDate(active);
-        setGroupedReservations(grouped);
-      } catch (err) {
-        console.error('예약 내역 불러오기 실패:', err);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchReservations();
-  }, [userId, accessToken]);
+    fetchReservations(resolvedUserId);
+  }, [authReady, resolvedUserId, accessToken]);
 
   const handleCancelReservation = (reservation) => {
     setCancelModalData(reservation);
   };
 
   const confirmCancelReservation = async () => {
-    if (!cancelModalData) return;
-
+    if (!cancelModalData || !resolvedUserId) return;
     try {
       const res = await axiosInstance.post('/api/reservations/cancel', {
-        userId,
+        userId: resolvedUserId,
         reservationId: cancelModalData.id,
       });
-      alert(res.data.message || '예약이 취소되었습니다.');
+      alert(res.data?.message || '예약이 취소되었습니다.');
       setCancelModalData(null);
 
-      const res2 = await axiosInstance.get(`/api/reservations/user/${userId}`);
-      const active = res2.data.reservations
-        .filter((r) => r.status === 'RESERVED')
-        .sort((a, b) => {
-          const getTime = (raw) =>
-            Array.isArray(raw) ? new Date(...raw) : new Date(raw);
-          return getTime(b.startTime) - getTime(a.startTime);
-        });
-      const grouped = groupByDate(active);
-      setGroupedReservations(grouped);
+      const res2 = await axiosInstance.get(
+        `/api/reservations/user/${resolvedUserId}?t=${Date.now()}`,
+      );
+      setGroupedReservations(buildGrouped(res2.data?.reservations));
 
-      if (fetchAllReservedTimes) {
-        await fetchAllReservedTimes();
-      }
+      if (fetchAllReservedTimes) await fetchAllReservedTimes();
     } catch (err) {
       console.error('예약 취소 실패:', err);
       alert(err.response?.data?.message || '예약 취소에 실패했습니다.');
@@ -114,37 +172,29 @@ const ReservationList = () => {
   };
 
   const formatDate = (input) => {
-    let date;
-    if (Array.isArray(input)) {
-      const [year, month, day] = input;
-      date = new Date(year, month - 1, day);
-    } else {
-      date = input ? new Date(input) : null;
-    }
-    return date ? `${date.getMonth() + 1}월 ${date.getDate()}일` : '--월 --일';
+    const d = toDateFromRaw(input);
+    return d ? `${d.getMonth() + 1}월 ${d.getDate()}일` : '--월 --일';
   };
-
   const formatTime = (input) => {
-    let date;
-    if (Array.isArray(input)) {
-      const [year, month, day, hour = 0, minute = 0] = input;
-      date = new Date(year, month - 1, day, hour, minute);
-    } else {
-      date = input ? new Date(input) : null;
-    }
-    if (!date) return '--:--';
-    const hours = String(date.getHours()).padStart(2, '0');
-    const minutes = String(date.getMinutes()).padStart(2, '0');
-    return `${hours}:${minutes}`;
+    const d = toDateFromRaw(input);
+    if (!d) return '--:--';
+    return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
   };
 
-  if (loading) return <div className="p-6">로딩 중...</div>;
+  if (!authReady || loading) return <div className="p-6">로딩 중...</div>;
+
+  const entries = Object.entries(groupedReservations).filter(
+    ([date]) => date !== 'Invalid Date',
+  );
 
   return (
     <div className="w-full">
-      {Object.entries(groupedReservations)
-        .filter(([date]) => date !== 'Invalid Date')
-        .map(([date, reservations]) => (
+      {entries.length === 0 ? (
+        <div className="p-6 text-sm text-[#73726e]">
+          표시할 예약 내역이 없습니다. (취소된 내역은 제외됩니다)
+        </div>
+      ) : (
+        entries.map(([date, reservations]) => (
           <div key={date} className="mb-6">
             <MyPageDate date={date} />
             {reservations.map((reservation) => (
@@ -155,7 +205,8 @@ const ReservationList = () => {
               />
             ))}
           </div>
-        ))}
+        ))
+      )}
 
       {cancelModalData && (
         <CancellationModal
@@ -187,6 +238,4 @@ const ReservationList = () => {
       )}
     </div>
   );
-};
-
-export default ReservationList;
+}

--- a/src/hooks/useAuthReady.js
+++ b/src/hooks/useAuthReady.js
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import useTokenStore from '../stores/useTokenStore';
+import { jwtDecode } from 'jwt-decode';
+
+export default function useAuthReady() {
+  const { accessToken, userId, setUserId, rehydrate } = useTokenStore();
+  const [authReady, setAuthReady] = useState(false);
+
+  useEffect(() => {
+    rehydrate();
+    const t = setTimeout(() => setAuthReady(true), 0);
+    return () => clearTimeout(t);
+  }, [rehydrate]);
+
+  useEffect(() => {
+    if (!authReady || userId || !accessToken) return;
+    try {
+      const d = jwtDecode(accessToken);
+      const uid = d?.userId ?? d?.id ?? d?.uid ?? d?.sub ?? null;
+      if (uid) setUserId(Number(uid));
+    } catch {
+      // ignore
+    }
+  }, [authReady, accessToken, userId, setUserId]);
+
+  return { authReady, accessToken, userId };
+}

--- a/src/libs/api/instance.js
+++ b/src/libs/api/instance.js
@@ -5,7 +5,6 @@ const axiosInstance = axios.create({
   timeout: 10000,
 });
 
-// 요청 인터셉터
 axiosInstance.interceptors.request.use(
   (config) => {
     if (typeof window !== 'undefined') {
@@ -16,14 +15,19 @@ axiosInstance.interceptors.request.use(
         '/user/code-verify',
       ];
 
-      // 인증이 필요 없는 요청이면 Authorization 제거
-      const isPublic = nonAuthUrls.some((url) => config.url?.includes(url));
+      config.headers = config.headers || {};
+
+      const url = config.url || '';
+      const isPublic = nonAuthUrls.some((u) => url.includes(u));
+
       if (isPublic) {
         delete config.headers.Authorization;
       } else {
         const accessToken = sessionStorage.getItem('accessToken');
         if (accessToken) {
-          config.headers['Authorization'] = `Bearer ${accessToken}`;
+          config.headers.Authorization = `Bearer ${accessToken}`;
+        } else {
+          delete config.headers.Authorization;
         }
       }
     }
@@ -42,7 +46,6 @@ axiosInstance.interceptors.response.use(
     const { response } = error;
     if (response && (response.status === 401 || response.status === 403)) {
       if (typeof window !== 'undefined') {
-        // 로그인이 필요한 경우 토큰 제거
         sessionStorage.removeItem('accessToken');
       }
     }

--- a/src/stores/useTokenStore.js
+++ b/src/stores/useTokenStore.js
@@ -19,25 +19,19 @@ const useTokenStore = create((set) => {
 
     setAccessToken: (token) => {
       set({ accessToken: token });
-      if (typeof window !== 'undefined') {
+      if (typeof window !== 'undefined')
         sessionStorage.setItem('accessToken', token);
-      }
     },
-
     setRefreshToken: (token) => {
       set({ refreshToken: token });
-      if (typeof window !== 'undefined') {
+      if (typeof window !== 'undefined')
         sessionStorage.setItem('refreshToken', token);
-      }
     },
-
     setUserId: (id) => {
       set({ userId: id });
-      if (typeof window !== 'undefined') {
-        sessionStorage.setItem('userId', id.toString());
-      }
+      if (typeof window !== 'undefined')
+        sessionStorage.setItem('userId', id?.toString() ?? '');
     },
-
     clearTokens: () => {
       set({ accessToken: '', refreshToken: '', userId: null });
       if (typeof window !== 'undefined') {
@@ -45,6 +39,18 @@ const useTokenStore = create((set) => {
         sessionStorage.removeItem('refreshToken');
         sessionStorage.removeItem('userId');
       }
+    },
+
+    rehydrate: () => {
+      if (typeof window === 'undefined') return;
+      const at = sessionStorage.getItem('accessToken') || '';
+      const rt = sessionStorage.getItem('refreshToken') || '';
+      const uid = sessionStorage.getItem('userId');
+      set({
+        accessToken: at,
+        refreshToken: rt,
+        userId: uid !== null ? parseInt(uid) : null,
+      });
     },
   };
 });


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/my-reservations-display-bug

### 💡 작업개요
- 비로그인 상태에서 /my/* 진입 시 로그인 화면으로 리다이렉트한 뒤, 로그인 직후 곧바로 마이페이지 → 예약내역으로 진입하면 실제 내역이 있음에도 ‘표시할 예약 내역이 없습니다’가 먼저 렌더되는 레이스 컨디션 존재
- 원인: 다음 세 플로우의 타이밍 경합
    1) 로그인 성공 직후: sessionStorage 쓰기 ↔ Zustand 스토어 반영(리하이드레이트) ↔ 최초 렌더/데이터 페치
    2) 첫 요청 시점에 Authorization 헤더가 비어 있을 가능성
    3) userId가 스토어에 아직 없어서 /user/{userId} 요청이 스킵되거나 빈 결과로 귀결
- 스토어 리하이드레이트, authReady 가드, 요청 인터셉터, 리다이렉트 지연, userId 자동 설정 도입/보강

### 🔑 주요 변경사항 
1. 인증/리다이렉트 타이밍 안정화
- 로그인 완료 → 리다이렉트 전에 50ms 지연
-- 토큰/`userId` 설정(setState)과 `sessionStorage` 커밋이 완료된 다음 페이지 전환되도록 보장
-- 영향 범위: 로그인 성공 핸들러 (기존 로직 보존, 지연만 추가)

2. 토큰 동기화 및 준비 상태 가드
- Zustand `useTokenStore`에 `rehydrate()` 도입
-- 진입 즉시 `sessionStorage → store` 동기화
- ReservationList에서 `authReady` 플래그 도입 및 100ms 지연
-- `rehydrate()` 이후 한 틱(100ms) 대기 → 준비 완료 전엔 ‘없음’ 렌더 금지, 준비되면 페치 시작
- sessionStorage 토큰 확인 로직 보강
-- `authReady`가 true이고 `accessToken`/`userId`가 준비된 경우에만 `/api/reservations/user/{id}` 호출

3. userId 자동 설정
- 로그인 시 JWT에서 `userId` 추출 후 스토어 자동 주입
-- 후보 키: `userId | id | uid | sub` (백엔드 페이로드 차이 흡수)
-- 로그인/리다이렉트 직후에도 `userId` 미설정 문제 해소

4. 첫 요청 신뢰성 확보(이전 작업 포함)
- Axios 요청 인터셉터: 매 요청 직전 `sessionStorage`에서 최신 토큰을 읽어 `Authorization` 헤더 설정(공개 URL은 제거)
- ReservationList 정합성 보강
-- 취소 내역 제외: `status` 정규화(대문자/trim) + `includes('CANCEL')` 및 `canceledAt/cancelledAt` 존재 시 제외
-- 날짜 파싱 일원화: `toDateFromRaw()`로 ISO/배열 모두 월-1 보정
-- 최초/재조회 캐시 우회: `?t=${Date.now()}` 파라미터 추가
-- 시작시간 내림차순 정렬 및 날짜별 그룹핑 유지

### 🏞 스크린샷


### 🔗 관련 이슈 
- #116
