### PR TITLE
[Fix] 오늘/내일 예약 모달에서 시작시간 재선택 시 1시간 단위 예약 실패 문제 해결

### DIFF
--- a/src/components/common/TomorrowReservationComponent.jsx
+++ b/src/components/common/TomorrowReservationComponent.jsx
@@ -9,6 +9,7 @@ import TimeComponent from '@components/common/TimeComponent';
 import Modal from '@components/common/Modal';
 import LoginRequiredModal from '@components/common/LoginRequiredModal';
 
+// 서버로 보낼 때 KST 로컬 시간을 ISO 형식(초까지)으로 전송
 const toKSTISOString = (date) => {
   const offset = date.getTimezoneOffset() * 60000;
   return new Date(date.getTime() - offset).toISOString().slice(0, 19);
@@ -17,10 +18,23 @@ const toKSTISOString = (date) => {
 const formatTime = (date) =>
   `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
 
+// 10분 슬롯 키 (밀리초 단위, 10분 경계에 맞춰 스냅)
+const slotKey10m = (d) => {
+  const t = new Date(d);
+  t.setSeconds(0, 0);
+  const m = t.getMinutes();
+  t.setMinutes(m - (m % 10));
+  return t.getTime();
+};
+
+const addMinutesISO = (iso, minutes) =>
+  new Date(new Date(iso).getTime() + minutes * 60000).toISOString();
+
 const TomorrowReservationComponent = ({ index, roomId }) => {
   const [open, setOpen] = useState(false);
   const [startTime, setStartTime] = useState('');
   const [endTime, setEndTime] = useState('');
+  const [durationMinutes, setDurationMinutes] = useState(null);
   const [showLoginModal, setShowLoginModal] = useState(false);
 
   const { userId, accessToken } = useTokenStore();
@@ -34,6 +48,7 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
   const reservedTimeSlots = reservedTimeSlotsByRoom?.[roomId] || [];
   const router = useRouter();
 
+  // 내일 00:00 기준일
   const tomorrow = useMemo(() => {
     const date = new Date();
     date.setDate(date.getDate() + 1);
@@ -52,6 +67,16 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
     return () => clearInterval(interval);
   }, [fetchAllReservedTimes]);
 
+  // 예약된 10분 슬롯 키 집합 (빠른 충돌 판정을 위해)
+  const reserved10mKeys = useMemo(() => {
+    const set = new Set();
+    for (const iso of reservedTimeSlots) {
+      set.add(slotKey10m(iso));
+    }
+    return set;
+  }, [reservedTimeSlots]);
+
+  // 내일의 10분 단위 타임슬롯 + 표시 전용 23:59
   const timeSlots = useMemo(() => {
     const slots = [];
     const base = new Date(tomorrow);
@@ -61,24 +86,31 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
       slots.push(new Date(base));
       base.setMinutes(base.getMinutes() + 10);
     }
-    slots.push(new Date(2025, 0, 2, 23, 59));
+    // 표시 전용 23:59
+    const disp = new Date(tomorrow);
+    disp.setHours(23, 59, 0, 0);
+    slots.push(disp);
     return slots;
   }, [tomorrow]);
 
-  const getStatus = (time) => {
-    if (time.endsWith('23:59:00')) return 'display-only';
-
-    // 내일 예약에서는 모든 시간이 미래시간이므로 예약된 시간만 회색으로 표시
-    const isReserved = reservedTimeSlots.includes(time);
-
-    let status;
-    if (isReserved) {
-      status = 'reserved';
-    } else {
-      status = 'available';
+  // 특정 구간이 예약과 충돌하는지 검사 (start 포함, end 제외)
+  const isRangeAvailable = (startISO, endISO) => {
+    const start = new Date(startISO);
+    const end = new Date(endISO);
+    const walker = new Date(start);
+    while (walker < end) {
+      if (reserved10mKeys.has(slotKey10m(walker))) return false;
+      walker.setMinutes(walker.getMinutes() + 10);
     }
+    return true;
+  };
 
-    return status;
+  const getStatus = (timeISO) => {
+    // 내일 화면은 전체가 미래이므로 past는 없음. 예약 여부만 표시.
+    // 표시 전용 23:59는 그냥 available과 동일하게 렌더(필요시 별도 처리)
+    const isReserved = reserved10mKeys.has(slotKey10m(timeISO));
+    if (isReserved) return 'reserved';
+    return 'available';
   };
 
   const handleOpenModal = () => {
@@ -102,7 +134,8 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
 
     const reservationStart = new Date(startTime);
     const reservationEnd = new Date(endTime);
-    const duration = (reservationEnd - reservationStart) / (1000 * 60);
+    const duration =
+      durationMinutes ?? (reservationEnd - reservationStart) / (1000 * 60);
 
     if (duration !== 60 && duration !== 120) {
       alert('예약은 1시간 또는 2시간 단위로만 가능합니다.');
@@ -119,38 +152,20 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
 
       alert(res.data.message || '예약이 완료되었습니다.');
 
-      await fetchLatestReservation();
-      await fetchAllUserReservations();
-      await fetchAllReservedTimes();
+      await Promise.all([
+        fetchLatestReservation(),
+        fetchAllUserReservations(),
+        fetchAllReservedTimes(),
+      ]);
 
       setOpen(false);
       setStartTime('');
       setEndTime('');
+      setDurationMinutes(null);
     } catch (err) {
       console.error('예약 실패:', err.response?.data || err.message);
       alert(err.response?.data?.message || '예약에 실패했습니다.');
     }
-  };
-
-  const renderTimeBlocks = () => {
-    const morning = timeSlots.filter((t) => t.getHours() < 12);
-    const afternoon = timeSlots.filter((t) => t.getHours() >= 12);
-    return (
-      <div className="flex flex-col gap-2">
-        {morning.length > 0 && (
-          <div>
-            <div className="text-xs font-semibold mb-1">오전</div>
-            {renderLine(morning)}
-          </div>
-        )}
-        {afternoon.length > 0 && (
-          <div>
-            <div className="text-xs font-semibold mb-1">오후</div>
-            {renderLine(afternoon)}
-          </div>
-        )}
-      </div>
-    );
   };
 
   const renderLine = (slots) => (
@@ -159,12 +174,12 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
         {slots.map((time) => {
           const hour = time.getHours();
           const isFirstOfHour = time.getMinutes() === 0;
-          const timeStr = time.toISOString();
-          const status = getStatus(timeStr);
+          const timeISO = time.toISOString();
+          const status = getStatus(timeISO);
 
           return (
             <div
-              key={timeStr}
+              key={timeISO}
               className="flex flex-col items-center"
               style={{ width: '10px' }}
             >
@@ -188,9 +203,30 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
     </div>
   );
 
+  const renderTimeBlocks = () => {
+    const morning = timeSlots.filter((t) => t.getHours() < 12);
+    const afternoon = timeSlots.filter((t) => t.getHours() >= 12);
+    return (
+      <div className="flex flex-col gap-2">
+        {morning.length > 0 && (
+          <div>
+            <div className="text-xs font-semibold mb-1">오전</div>
+            {renderLine(morning)}
+          </div>
+        )}
+        {afternoon.length > 0 && (
+          <div>
+            <div className="text-xs font-semibold mb-1">오후</div>
+            {renderLine(afternoon)}
+          </div>
+        )}
+      </div>
+    );
+  };
+
   const renderStartTimeOptions = () => {
     return timeSlots
-      .filter((time) => !reservedTimeSlots.includes(time.toISOString()))
+      .filter((time) => !reserved10mKeys.has(slotKey10m(time)))
       .map((time) => (
         <option key={time.toISOString()} value={time.toISOString()}>
           {formatTime(time)}
@@ -201,12 +237,14 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
   const renderEndTimeOptions = () => {
     if (!startTime) return [];
     const start = new Date(startTime);
-    const end1 = new Date(start);
-    const end2 = new Date(start);
-    end1.setMinutes(end1.getMinutes() + 60);
-    end2.setMinutes(end2.getMinutes() + 120);
+    const end1 = new Date(start.getTime() + 60 * 60000);
+    const end2 = new Date(start.getTime() + 120 * 60000);
 
-    return [end1, end2].map((time) => (
+    const candidates = [end1, end2].filter((time) =>
+      isRangeAvailable(start.toISOString(), time.toISOString()),
+    );
+
+    return candidates.map((time) => (
       <option key={time.toISOString()} value={time.toISOString()}>
         {formatTime(time)}
       </option>
@@ -243,7 +281,26 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
               <select
                 className="border rounded-md p-2 w-full"
                 value={startTime}
-                onChange={(e) => setStartTime(e.target.value)}
+                onChange={(e) => {
+                  const newStart = e.target.value;
+                  setStartTime(newStart);
+
+                  const tryAuto = (len) => {
+                    const candidateEnd = addMinutesISO(newStart, len);
+                    if (isRangeAvailable(newStart, candidateEnd)) {
+                      setEndTime(candidateEnd);
+                      setDurationMinutes(len);
+                    } else {
+                      setEndTime('');
+                    }
+                  };
+
+                  if (durationMinutes) {
+                    tryAuto(durationMinutes);
+                  } else {
+                    tryAuto(60);
+                  }
+                }}
               >
                 <option value="" disabled>
                   시간 선택
@@ -256,7 +313,16 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
               <select
                 className="border rounded-md p-2 w-full"
                 value={endTime}
-                onChange={(e) => setEndTime(e.target.value)}
+                onChange={(e) => {
+                  const selectedEnd = e.target.value;
+                  setEndTime(selectedEnd);
+                  if (startTime) {
+                    const dur =
+                      (new Date(selectedEnd) - new Date(startTime)) /
+                      (1000 * 60);
+                    if (dur === 60 || dur === 120) setDurationMinutes(dur);
+                  }
+                }}
                 disabled={!startTime}
               >
                 <option value="" disabled>


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/home-hourly-reservation-bug

### 💡 작업개요
- 오늘·내일 예약 모달에서 시작/종료시간을 선택한 뒤 다시 시작시간의 분을 변경하면, 1시간(또는 2시간) 단위 예약 검증이 깨지거나 종료시간이 자동으로 맞춰지지 않아 예약 생성이 실패하던 문제 수정
- 사용자가 선택한 예약 길이(1h/2h)를 기억하고, 시작시간이 바뀌면 그 길이에 맞춰 종료시간을 자동 보정하며, 예약된 10분 슬롯과의 충돌을 사전에 차단하도록 로직 정리

### 🔑 주요 변경사항 
1. `ReservationComponent.jsx`
- **예약 길이 상태 도입**: `durationMinutes`(60\|120)로 사용자의 선택 길이를 기억.
- **시작시간 변경 → 종료시간 자동 보정**  
  - `durationMinutes`가 있으면 해당 길이로 `endTime` 재계산  
  - 길이 정보가 없으면 기본 1시간 제안(가능할 때만)
- **충돌 검사**: `isRangeAvailable(startISO, endISO)`로 10분 단위 순회하며 예약 슬롯과 겹치면 `endTime` 초기화(재선택 유도)
- **퇴실시간 옵션 필터링**: 1시간/2시간 후보 중 **충돌 없는** 옵션만 제공
- **서버 전송 포맷 일원화**: `toKSTISOString(date)`로 **KST 기준 초단위 ISO 문자열** 전송

2. `TomorrowReservationComponent.jsx`
- **동일한 UX 정렬**: `durationMinutes` 유지 + 시작시간 변경 시 `endTime` 자동 보정
- **고속 충돌 판정**: `slotKey10m()`으로 10분 슬롯 키를 만들고, `reserved10mKeys(Set)`로 **O(1)** 판정
- **퇴실시간 옵션 필터링**: 홈과 동일하게 1h/2h 후보 중 **충돌 없는** 옵션만 노출
- **서버 전송 포맷 일원화**: `toKSTISOString(date)` 사용

### 🏞 스크린샷


### 🔗 관련 이슈 
- #129
