### PR TITLE
[Feat] Google Analytics(GA4) 연동 및 전역 추적 스크립트 적용

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -1,4 +1,5 @@
 import './globals.css';
+import Script from 'next/script';
 
 export const metadata = {
   title: 'DdingsRoom | 명지대학교 학생회관 스터디룸 예약 서비스',
@@ -8,7 +9,21 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="ko">
-      <body>{children}</body>
+      <body>
+        {children}
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-6XKZ627HGM"
+          strategy="afterInteractive"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-6XKZ627HGM');
+          `}
+        </Script>
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- docs/update-user-manual

### 💡 작업개요
- Google Analytics(GA4)를 프로젝트 전역에 연동하여 사용자 행동 및 페이지뷰 데이터 수집할 수 있도록 설정
- `app/layout.js`에 GA4 추적 스니펫을 삽입해 모든 페이지에서 공통으로 작동하며, Next.js의 `next/script`를 사용해 로딩 전략을 최적화

### 🔑 주요 변경사항 
1. **GA4 추적 스크립트 삽입**
   - Google Tag Manager 스니펫을 `app/layout.js`에 추가
   - `<Script src="https://www.googletagmanager.com/gtag/js?id=G-XXXX" />`로 비동기 로드
   - 두 번째 `<Script>`에서 `window.dataLayer` 초기화 및 `gtag()` 함수 설정
   - `gtag('config', 'G-XXXX')` 호출로 기본 페이지뷰 추적 활성화

2. **Next.js 성능 최적화 적용**
   - `strategy="afterInteractive"`로 설정하여 페이지 인터랙션 이후 스크립트 로드 → 초기 렌더링 성능 저하 방지
   - 모든 페이지 공통 레이아웃에 삽입해 중복 로드 방지

3. **구조적 적용**
   - `<html>` 태그 내 `<body>` 하단에 삽입하여 DOM이 준비된 뒤 실행
   - 기존 전역 스타일(`globals.css`) 및 레이아웃 구조 유지

### 🏞 스크린샷


### 🔗 관련 이슈 
- #142
