### PR TITLE
[Fix] 이름 변경 실패 시 서버 에러 메시지 그대로 노출(중복 이름 409 대응)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "lint": "next lint"
   },
   "engines": {
-    "node": "20.x"
+    "node": ">=20 <23"
   },
+  "packageManager": "yarn@1.22.21",
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/username-duplicate-error-message

### 💡 작업개요
- 이름 변경 시 프론트에서 일괄적으로 `"이름 변경에 실패했습니다."`만 표시되던 문제를 수정
- 서버가 반환하는 구체 에러 메시지(예: “중복된 이름입니다.”)를 그대로 사용자에게 노출

### 🔑 주요 변경사항 
### 1. 에러 메시지 전달 개선
- `axiosInstance.put('/user/change-username')` 실패 시:
  - `response.data.message` → `response.data.error` → `string body` 순으로 파싱
  - 파싱 실패 시에만 안전한 일반 문구로 폴백
- HTTP 상태코드 분기 처리:
  - **409 Conflict**: 중복 이름 → 서버 메시지 우선 노출 (폴백: `"중복된 이름입니다."`)
  - **400 Bad Request**: 잘못된 요청 → 서버 메시지 우선
  - **기타**: 서버 메시지 또는 일반 문구로 폴백

### 2. 사전 검증 & UX 보강
- `newName.trim()` **빈값 제출 방지**
- 기존 이름과 동일한 값 제출 방지
- `submitting` 상태 도입 → **중복 클릭 방지** 및 버튼 라벨 `"수정 중…"` 표시
- 성공 시 `userInfo.name` 즉시 갱신, 입력/모달 초기화

### 3. 로깅/안정성
- `console.error('이름 변경 실패:', err)` **컨텍스트 포함 로깅**
- 예외 케이스 전반에서 안전한 폴백 처리

### 🏞 스크린샷


### 🔗 관련 이슈 
- #155
