### PR TITLE
[Chore] GA4 재연결(기본 gtag 스니펫 측정ID 교체)

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -61,8 +61,9 @@ export default function RootLayout({ children }) {
     <html lang="ko">
       <body>
         {children}
+
         <Script
-          src="https://www.googletagmanager.com/gtag/js?id=G-6XKZ627HGM"
+          src="https://www.googletagmanager.com/gtag/js?id=G-NEXY3X7HZG"
           strategy="afterInteractive"
         />
         <Script id="google-analytics" strategy="afterInteractive">
@@ -70,7 +71,7 @@ export default function RootLayout({ children }) {
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
-            gtag('config', 'G-6XKZ627HGM');
+            gtag('config', 'G-NEXY3X7HZG');
           `}
         </Script>
       </body>


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/reconnect-google-analytics

### 💡 작업개요
- Google Analytics 계정 변경에 따라 기본 GA4 스니펫의 측정ID만 교체
- Next.js App Router의 RootLayout 내에 단일 스니펫으로 유지하며, 스크립트 로딩 전략은 기존과 동일하게 afterInteractive 사용
- 추가 이벤트 설계/수동 page_view 전송 없이 기본 페이지뷰 수집을 재개하는 데 목적

### 🔑 주요 변경사항 
- `app/layout.jsx` 변경사항
-- 외부 스크립트 URL 교체 (`https://www.googletagmanager.com/gtag/js?id=G-NEXY3X7HZG`)
-- 초기화 스니펫의 측정ID 교체 (`gtag('config', 'G-NEXY3X7HZG');`)
-- 로딩 전략 유지 (`strategy="afterInteractive"`, 클라이언트 상호작용 이후 비동기 로드)
-- 스니펫 관리 (`RootLayout` 단일 삽입으로 유지, 중복 삽입 방지 → 이중 집계 방지)

### 🏞 스크린샷


### 🔗 관련 이슈 
- #161 
