### PR TITLE
[Feat] 커뮤니티·공지 하단 Footer 공통화 & ‘예약하기’ 홈 이동 버튼 추가

### DIFF
--- a/src/app/admin/dashboard/page.jsx
+++ b/src/app/admin/dashboard/page.jsx
@@ -98,7 +98,7 @@ export default function AdminDashboard() {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       window.removeEventListener('focus', fetchRoomData);
     };
-  }, []);
+  }, [fetchCommunityData, fetchSuggestionsData]);
 
   const formatTimeRange = (start, end) => {
     const formatHM = (arr) => {
@@ -133,9 +133,11 @@ export default function AdminDashboard() {
       const response = await axiosInstance.get('/api/suggestions', {
         params: { is_answered: 'false' },
       });
-      const suggestions = (response?.data?.suggestions ?? response?.data ?? []).map(
-        normalizeSuggestion,
-      );
+      const suggestions = (
+        response?.data?.suggestions ??
+        response?.data ??
+        []
+      ).map(normalizeSuggestion);
       setSuggestionsData(suggestions.slice(0, 3));
     } catch (err) {
       console.error('건의 데이터 불러오기 실패:', err);
@@ -281,7 +283,9 @@ export default function AdminDashboard() {
               ))
             ) : (
               <li className="p-3 bg-gray-50 rounded-lg">
-                <p className="text-sm text-gray-500">커뮤니티 게시글이 없습니다.</p>
+                <p className="text-sm text-gray-500">
+                  커뮤니티 게시글이 없습니다.
+                </p>
               </li>
             )}
           </ul>
@@ -318,9 +322,7 @@ export default function AdminDashboard() {
                     <p className="text-sm font-medium text-[#37352f]">
                       스터디룸 {room.id}
                     </p>
-                    <p className="text-xs text-[#73726e]">
-                      방 번호: {room.id}
-                    </p>
+                    <p className="text-xs text-[#73726e]">방 번호: {room.id}</p>
                   </div>
                 </div>
                 <div>
@@ -329,15 +331,15 @@ export default function AdminDashboard() {
                       room.status === 'IDLE'
                         ? 'bg-green-100 text-green-700'
                         : room.status === 'OCCUPIED'
-                        ? 'bg-amber-100 text-amber-700'
-                        : 'bg-gray-100 text-gray-600'
+                          ? 'bg-amber-100 text-amber-700'
+                          : 'bg-gray-100 text-gray-600'
                     }`}
                   >
                     {room.status === 'IDLE'
                       ? '예약 가능'
                       : room.status === 'OCCUPIED'
-                      ? '사용 중'
-                      : '예약 불가'}
+                        ? '사용 중'
+                        : '예약 불가'}
                   </span>
                 </div>
               </div>
@@ -369,13 +371,16 @@ export default function AdminDashboard() {
                     [{suggestion.category}] {suggestion.title}
                   </p>
                   <p className="text-xs text-[#73726e]">
-                    USER {suggestion.userId} · {formatTimestamp(suggestion.createdAt)}
+                    USER {suggestion.userId} ·{' '}
+                    {formatTimestamp(suggestion.createdAt)}
                   </p>
                 </li>
               ))
             ) : (
               <li className="p-3 bg-gray-50 rounded-lg">
-                <p className="text-sm text-gray-500">답변대기 건의가 없습니다.</p>
+                <p className="text-sm text-gray-500">
+                  답변대기 건의가 없습니다.
+                </p>
               </li>
             )}
           </ul>

--- a/src/app/admin/layout.jsx
+++ b/src/app/admin/layout.jsx
@@ -65,7 +65,6 @@ export default function AdminLayout({ children }) {
                 className="hover:text-[#788cff] transition-colors"
               >
                 공지사항 관리
-
               </a>
             </nav>
           </aside>

--- a/src/app/admin/notifications/page.jsx
+++ b/src/app/admin/notifications/page.jsx
@@ -12,7 +12,7 @@ export default function NotificationManagement() {
   const [showEditForm, setShowEditForm] = useState(false);
   const [formData, setFormData] = useState({
     title: '',
-    content: ''
+    content: '',
   });
 
   useEffect(() => {
@@ -45,9 +45,9 @@ export default function NotificationManagement() {
     try {
       const response = await axiosInstance.post('/api/notification/create', {
         title: formData.title,
-        content: formData.content
+        content: formData.content,
       });
-      
+
       if (response.data.error) {
         alert(response.data.error);
         return;
@@ -73,9 +73,9 @@ export default function NotificationManagement() {
       const response = await axiosInstance.put('/api/notification/update', {
         notificationId: selectedNotification.id,
         title: formData.title,
-        content: formData.content
+        content: formData.content,
       });
-      
+
       if (response.data.error) {
         alert(response.data.error);
         return;
@@ -98,8 +98,10 @@ export default function NotificationManagement() {
     }
 
     try {
-      const response = await axiosInstance.delete(`/api/notification/delete/${notificationId}`);
-      
+      const response = await axiosInstance.delete(
+        `/api/notification/delete/${notificationId}`,
+      );
+
       if (response.data.error) {
         alert(response.data.error);
         return;
@@ -115,7 +117,7 @@ export default function NotificationManagement() {
 
   const formatDate = (dateArray) => {
     if (!Array.isArray(dateArray) || dateArray.length < 6) return '';
-    const [year, month, day, hour, minute, second] = dateArray;
+    const [year, month, day, hour, minute] = dateArray;
     return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')} ${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
   };
 
@@ -127,12 +129,14 @@ export default function NotificationManagement() {
 
   const truncateContent = (content, maxLength = 50) => {
     if (!content) return '';
-    return content.length > maxLength ? content.substring(0, maxLength) + '...' : content;
+    return content.length > maxLength
+      ? content.substring(0, maxLength) + '...'
+      : content;
   };
 
   const groupNotificationsByDate = (notifications) => {
     const grouped = {};
-    notifications.forEach(notification => {
+    notifications.forEach((notification) => {
       const dateKey = formatDateOnly(notification.createdAt);
       if (!grouped[dateKey]) {
         grouped[dateKey] = [];
@@ -155,7 +159,7 @@ export default function NotificationManagement() {
     setSelectedNotification(notification);
     setFormData({
       title: notification.title,
-      content: notification.content
+      content: notification.content,
     });
     setShowDetailModal(false);
     setShowEditForm(true);
@@ -186,7 +190,9 @@ export default function NotificationManagement() {
               <input
                 type="text"
                 value={formData.title}
-                onChange={(e) => setFormData(prev => ({ ...prev, title: e.target.value }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({ ...prev, title: e.target.value }))
+                }
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--primary-color)]"
                 placeholder="공지사항 제목을 입력하세요"
               />
@@ -198,7 +204,9 @@ export default function NotificationManagement() {
               </label>
               <textarea
                 value={formData.content}
-                onChange={(e) => setFormData(prev => ({ ...prev, content: e.target.value }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({ ...prev, content: e.target.value }))
+                }
                 rows={15}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--primary-color)] resize-y"
                 placeholder="공지사항 내용을 입력하세요"
@@ -255,7 +263,9 @@ export default function NotificationManagement() {
               <input
                 type="text"
                 value={formData.title}
-                onChange={(e) => setFormData(prev => ({ ...prev, title: e.target.value }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({ ...prev, title: e.target.value }))
+                }
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--primary-color)]"
                 placeholder="공지사항 제목을 입력하세요"
               />
@@ -267,7 +277,9 @@ export default function NotificationManagement() {
               </label>
               <textarea
                 value={formData.content}
-                onChange={(e) => setFormData(prev => ({ ...prev, content: e.target.value }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({ ...prev, content: e.target.value }))
+                }
                 rows={15}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--primary-color)] resize-y"
                 placeholder="공지사항 내용을 입력하세요"
@@ -306,12 +318,15 @@ export default function NotificationManagement() {
     <div className="bg-[#F1F2F4] p-6 min-h-screen">
       <div className="bg-white p-4 rounded-lg shadow-sm">
         <h1 className="text-lg font-semibold mb-4">공지사항 관리</h1>
-        
+
         <div className="mb-6">
           <button
             onClick={() => setShowCreateForm(true)}
             className="px-4 py-2 text-white rounded transition-colors"
-            style={{ backgroundColor: 'var(--primary-color)', borderColor: 'var(--primary-color)' }}
+            style={{
+              backgroundColor: 'var(--primary-color)',
+              borderColor: 'var(--primary-color)',
+            }}
           >
             공지사항 작성
           </button>
@@ -370,11 +385,15 @@ export default function NotificationManagement() {
                   ✕
                 </button>
               </div>
-              
+
               <div className="mb-4 pb-4 border-b border-gray-200">
                 <div className="flex items-center text-sm text-gray-500 gap-4">
-                  <span>작성일: {formatDate(selectedNotification.createdAt)}</span>
-                  <span>수정일: {formatDate(selectedNotification.updatedAt)}</span>
+                  <span>
+                    작성일: {formatDate(selectedNotification.createdAt)}
+                  </span>
+                  <span>
+                    수정일: {formatDate(selectedNotification.updatedAt)}
+                  </span>
                   <span>조회수: {selectedNotification.viewCount}</span>
                 </div>
               </div>
@@ -418,7 +437,12 @@ export default function NotificationManagement() {
   );
 }
 
-function NotificationCard({ notification, onDetailClick, formatDate, truncateContent }) {
+function NotificationCard({
+  notification,
+  onDetailClick,
+  formatDate,
+  truncateContent,
+}) {
   return (
     <article className="relative rounded-xl border bg-white shadow-sm overflow-hidden transition hover:shadow-md">
       <div
@@ -446,7 +470,8 @@ function NotificationCard({ notification, onDetailClick, formatDate, truncateCon
             </p>
 
             <p className="mt-2 text-[11px] text-gray-400">
-              작성일: {formatDate(notification.createdAt)} · 조회수: {notification.viewCount}
+              작성일: {formatDate(notification.createdAt)} · 조회수:{' '}
+              {notification.viewCount}
             </p>
           </div>
 

--- a/src/app/admin/reservations-by-date/page.jsx
+++ b/src/app/admin/reservations-by-date/page.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { jwtDecode } from 'jwt-decode';
 import axiosInstance from '../../../libs/api/instance';
@@ -157,7 +157,9 @@ export default function ReservationListPage() {
                           className={`px-3 py-2 text-sm rounded-md border bg-white text-red-600 border-red-300
                               hover:bg-red-50 hover:border-red-400 transition ${
                                 // eslint-disable-next-line prettier/prettier
-                                isCancelling ? 'opacity-60 cursor-not-allowed' : ''
+                                isCancelling
+                                  ? 'opacity-60 cursor-not-allowed'
+                                  : ''
                               }`}
                           aria-busy={isCancelling ? 'true' : 'false'}
                           title="관리자 권한으로 예약을 강제 취소합니다"

--- a/src/app/admin/room-management/page.jsx
+++ b/src/app/admin/room-management/page.jsx
@@ -156,7 +156,7 @@ export default function RoomsManagePage() {
         });
       }
     },
-    [rooms, fetchRoom],
+    [rooms],
   );
 
   if (loading) {

--- a/src/app/admin/user-detail/[userId]/page.jsx
+++ b/src/app/admin/user-detail/[userId]/page.jsx
@@ -51,7 +51,7 @@ export default function UserDetailPage() {
   const [user, setUser] = useState(null);
   const [reservations, setReservations] = useState([]);
   const [loadingReservations, setLoadingReservations] = useState(true);
-  const [updatingStatus, setUpdatingStatus] = useState(false);
+  // const [updatingStatus, setUpdatingStatus] = useState(false);
 
   useEffect(() => {
     if (!accessToken) {
@@ -100,7 +100,7 @@ export default function UserDetailPage() {
   }, [userId, fetchUserDetail, fetchUserReservations]);
 
   const userStatus = useMemo(() => deriveStatus(user), [user]);
-  const isBlocked = userStatus === 'blocked';
+  // const isBlocked = userStatus === 'blocked';
 
   const updateUserStatus = useCallback(
     async (nextStatus) => {
@@ -127,14 +127,14 @@ export default function UserDetailPage() {
         console.log(`Updating user ${userId} status to:`, nextStatus);
 
         const response = await axiosInstance.put(
-          `/admin/users/${userId}/status`, 
-          null, 
+          `/admin/users/${userId}/status`,
+          null,
           {
             params: { status: nextStatus },
             headers: {
-              'Authorization': `Bearer ${accessToken}`
-            }
-          }
+              Authorization: `Bearer ${accessToken}`,
+            },
+          },
         );
 
         console.log('User status update success:', response.data);
@@ -147,7 +147,7 @@ export default function UserDetailPage() {
         }
       } catch (e) {
         console.error('사용자 상태 변경 실패:', e);
-        
+
         // 실패 시 이전 상태로 롤백
         setUser(prevUser);
         throw e;
@@ -156,30 +156,32 @@ export default function UserDetailPage() {
     [userId, user, fetchUserDetail, accessToken],
   );
 
-  const handleStatusToggle = useCallback(async () => {
-    if (!user) return;
-    
-    const currentStatus = userStatus;
-    const newStatus = currentStatus === 'normal' ? 'blocked' : 'normal';
-    const statusText = newStatus === 'blocked' ? '차단' : '정상';
+  // const handleStatusToggle = useCallback(async () => {
+  if (!user) return;
 
-    if (!confirm(`${user.username}님을 ${statusText} 상태로 변경하시겠습니까?`)) {
-      return;
-    }
+  const currentStatus = userStatus;
+  const newStatus = currentStatus === 'normal' ? 'blocked' : 'normal';
+  const statusText = newStatus === 'blocked' ? '차단' : '정상';
 
-    setUpdatingStatus(true);
+  // if (
+  //   !confirm(`${user.username}님을 ${statusText} 상태로 변경하시겠습니까?`)
+  // ) {
+  //   return;
+  // }
 
-    try {
-      await updateUserStatus(newStatus);
-      alert(`${user.username}님이 ${statusText} 상태로 변경되었습니다.`);
-    } catch (error) {
-      console.error('사용자 상태 변경 실패:', error);
-      const msg = error?.response?.data?.message || '상태 변경에 실패했습니다.';
-      alert(msg);
-    } finally {
-      setUpdatingStatus(false);
-    }
-  }, [user, userStatus, updateUserStatus]);
+  // setUpdatingStatus(true);
+
+  // try {
+  //   await updateUserStatus(newStatus);
+  //   alert(`${user.username}님이 ${statusText} 상태로 변경되었습니다.`);
+  // } catch (error) {
+  //   console.error('사용자 상태 변경 실패:', error);
+  //   const msg = error?.response?.data?.message || '상태 변경에 실패했습니다.';
+  //   alert(msg);
+  // } finally {
+  //   setUpdatingStatus(false);
+  // }
+  // }, [user, userStatus, updateUserStatus]);
 
   /* Loading */
   if (!user) return <p className="p-6">로딩 중...</p>;
@@ -196,7 +198,6 @@ export default function UserDetailPage() {
           </button>
           <h1 className="text-xl font-semibold">{user.username}</h1>
         </div>
-
       </div>
 
       {/* Cards */}

--- a/src/app/admin/user-management/page.jsx
+++ b/src/app/admin/user-management/page.jsx
@@ -50,10 +50,8 @@ export default function UserManagement() {
   };
 
   const handleUserUpdate = (userId, updatedUser) => {
-    setUsers(prevUsers => 
-      prevUsers.map(user => 
-        user.id === userId ? updatedUser : user
-      )
+    setUsers((prevUsers) =>
+      prevUsers.map((user) => (user.id === userId ? updatedUser : user)),
     );
   };
 
@@ -91,9 +89,9 @@ export default function UserManagement() {
             <tbody className="bg-white">
               {Array.isArray(users) ? (
                 users.map((user) => (
-                  <UserTableRow 
-                    key={user.id} 
-                    user={user} 
+                  <UserTableRow
+                    key={user.id}
+                    user={user}
                     onUserUpdate={handleUserUpdate}
                   />
                 ))

--- a/src/app/community/[postId]/edit/page.jsx
+++ b/src/app/community/[postId]/edit/page.jsx
@@ -45,7 +45,7 @@ export default function EditPostPage() {
     if (accessToken && postId) {
       fetchPost();
     }
-  }, [accessToken, postId]);
+  }, [accessToken, postId, fetchPost]);
 
   const fetchPost = async () => {
     try {

--- a/src/app/community/[postId]/edit/page.jsx
+++ b/src/app/community/[postId]/edit/page.jsx
@@ -8,6 +8,17 @@ import CommunityHeader from '@components/community/CommunityHeader';
 import LoginRequiredModal from '@components/common/LoginRequiredModal';
 import Modal from '@components/common/Modal';
 import Button from '@components/common/Button';
+import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
+import FooterNav from '@components/common/FooterNav';
+
+function BottomSafeSpacer({ height = 64 }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ height: `calc(${height}px + env(safe-area-inset-bottom, 0px))` }}
+    />
+  );
+}
 
 export default function EditPostPage() {
   const [title, setTitle] = useState('');
@@ -152,7 +163,7 @@ export default function EditPostPage() {
     <div className="min-h-screen bg-gray-50 flex flex-col">
       <CommunityHeader title="게시글 수정" />
 
-      <main className="flex-1 p-4">
+      <main className="flex-1 p-4 pb-32">
         <div className="bg-white rounded-lg shadow-sm border border-gray-100">
           <form onSubmit={handleSubmit} className="p-6 space-y-6">
             <div>
@@ -256,6 +267,10 @@ export default function EditPostPage() {
         content={errorMessage}
         showCancel={false}
       />
+
+      <PrivacyPolicyFooter />
+      <BottomSafeSpacer height={64} />
+      <FooterNav />
     </div>
   );
 }

--- a/src/app/community/[postId]/page.jsx
+++ b/src/app/community/[postId]/page.jsx
@@ -9,6 +9,17 @@ import CommunityHeader from '@components/community/CommunityHeader';
 import CommentItem from '@components/community/CommentItem';
 import LoginRequiredModal from '@components/common/LoginRequiredModal';
 import Modal from '@components/common/Modal';
+import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
+import FooterNav from '@components/common/FooterNav';
+
+function BottomSafeSpacer({ height = 64 }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ height: `calc(${height}px + env(safe-area-inset-bottom, 0px))` }}
+    />
+  );
+}
 
 export default function PostDetailPage() {
   const [post, setPost] = useState(null);
@@ -231,7 +242,7 @@ export default function PostDetailPage() {
     <div className="min-h-screen bg-gray-50 flex flex-col">
       <CommunityHeader title="게시글 상세" />
 
-      <main className="flex-1 p-4 pb-20">
+      <main className="flex-1 p-4 pb-32">
         <div className="bg-white rounded-lg shadow-sm border border-gray-100 mb-4">
           <div className="p-6">
             <div
@@ -344,6 +355,10 @@ export default function PostDetailPage() {
         content={errorMessage}
         showCancel={false}
       />
+
+      <PrivacyPolicyFooter />
+      <BottomSafeSpacer height={64} />
+      <FooterNav />
     </div>
   );
 }

--- a/src/app/community/[postId]/page.jsx
+++ b/src/app/community/[postId]/page.jsx
@@ -48,7 +48,7 @@ export default function PostDetailPage() {
       fetchPostDetail();
       fetchComments();
     }
-  }, [accessToken, postId]);
+  }, [accessToken, postId, fetchPostDetail, fetchComments]);
 
   const fetchPostDetail = async () => {
     try {

--- a/src/app/community/page.jsx
+++ b/src/app/community/page.jsx
@@ -8,6 +8,17 @@ import CommunityHeader from '@components/community/CommunityHeader';
 import PostCard from '@components/community/PostCard';
 import LoginRequiredModal from '@components/common/LoginRequiredModal';
 import Modal from '@components/common/Modal';
+import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
+import FooterNav from '@components/common/FooterNav';
+
+function BottomSafeSpacer({ height = 64 }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ height: `calc(${height}px + env(safe-area-inset-bottom, 0px))` }}
+    />
+  );
+}
 
 export default function CommunityPage() {
   const [posts, setPosts] = useState([]);
@@ -122,7 +133,7 @@ export default function CommunityPage() {
         </div>
       </div>
 
-      <main className="flex-1 p-4 pb-20">
+      <main className="flex-1 p-4 pb-32">
         {isLoading ? (
           <div className="flex justify-center items-center py-20">
             <div className="text-[#73726e]">로딩 중...</div>
@@ -173,6 +184,10 @@ export default function CommunityPage() {
         content={errorMessage}
         showCancel={false}
       />
+
+      <PrivacyPolicyFooter />
+      <BottomSafeSpacer height={64} />
+      <FooterNav />
     </div>
   );
 }

--- a/src/app/community/page.jsx
+++ b/src/app/community/page.jsx
@@ -42,7 +42,7 @@ export default function CommunityPage() {
     if (accessToken) {
       fetchPosts();
     }
-  }, [accessToken, activeCategory]);
+  }, [accessToken, activeCategory, fetchPosts]);
 
   const fetchPosts = async () => {
     try {

--- a/src/app/community/write/page.jsx
+++ b/src/app/community/write/page.jsx
@@ -8,6 +8,17 @@ import CommunityHeader from '@components/community/CommunityHeader';
 import LoginRequiredModal from '@components/common/LoginRequiredModal';
 import Modal from '@components/common/Modal';
 import Button from '@components/common/Button';
+import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
+import FooterNav from '@components/common/FooterNav';
+
+function BottomSafeSpacer({ height = 64 }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ height: `calc(${height}px + env(safe-area-inset-bottom, 0px))` }}
+    />
+  );
+}
 
 export default function WritePostPage() {
   const [title, setTitle] = useState('');
@@ -88,7 +99,7 @@ export default function WritePostPage() {
     <div className="min-h-screen bg-gray-50 flex flex-col">
       <CommunityHeader title="게시글 작성" />
 
-      <main className="flex-1 p-4">
+      <main className="flex-1 p-4 pb-32">
         <div className="bg-white rounded-lg shadow-sm border border-gray-100">
           <form onSubmit={handleSubmit} className="p-6 space-y-6">
             <div>
@@ -192,6 +203,10 @@ export default function WritePostPage() {
         content={errorMessage}
         showCancel={false}
       />
+
+      <PrivacyPolicyFooter />
+      <BottomSafeSpacer height={64} />
+      <FooterNav />
     </div>
   );
 }

--- a/src/app/email-verification-manual/page.jsx
+++ b/src/app/email-verification-manual/page.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Link from 'next/link';
+// import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 const updatedAt = '2025-08-19 (KST)';

--- a/src/app/notifications/page.jsx
+++ b/src/app/notifications/page.jsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
 import axiosInstance from '../../libs/api/instance';
 import Header from '@components/common/Header';
 import FooterNav from '@components/common/FooterNav';
@@ -12,7 +11,7 @@ export default function NotificationList() {
   const [isLoading, setIsLoading] = useState(false);
   const [selectedNotification, setSelectedNotification] = useState(null);
   const [showDetailModal, setShowDetailModal] = useState(false);
-  const router = useRouter();
+  // const router = useRouter();
 
   useEffect(() => {
     fetchNotifications();
@@ -55,7 +54,7 @@ export default function NotificationList() {
 
   const formatDate = (dateArray) => {
     if (!Array.isArray(dateArray) || dateArray.length < 6) return '';
-    const [year, month, day, hour, minute, second] = dateArray;
+    const [year, month, day, hour, minute] = dateArray;
     return `${year}.${String(month).padStart(2, '0')}.${String(day).padStart(2, '0')} ${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
   };
 

--- a/src/app/notifications/page.jsx
+++ b/src/app/notifications/page.jsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import axiosInstance from '../../libs/api/instance';
 import Header from '@components/common/Header';
 import FooterNav from '@components/common/FooterNav';
+import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
 
 export default function NotificationList() {
   const [notifications, setNotifications] = useState([]);
@@ -37,12 +38,12 @@ export default function NotificationList() {
   const handleViewNotification = async (notification) => {
     try {
       await axiosInstance.post('/api/notification/view', {
-        notificationId: notification.id
+        notificationId: notification.id,
       });
-      
+
       setSelectedNotification({
         ...notification,
-        viewCount: notification.viewCount + 1
+        viewCount: notification.viewCount + 1,
       });
       setShowDetailModal(true);
     } catch (error) {
@@ -60,8 +61,21 @@ export default function NotificationList() {
 
   const truncateContent = (content, maxLength = 50) => {
     if (!content) return '';
-    return content.length > maxLength ? content.substring(0, maxLength) + '...' : content;
+    return content.length > maxLength
+      ? content.substring(0, maxLength) + '...'
+      : content;
   };
+
+  function BottomSafeSpacer({ height = 64 }) {
+    return (
+      <div
+        aria-hidden="true"
+        style={{
+          height: `calc(${height}px + env(safe-area-inset-bottom, 0px))`,
+        }}
+      />
+    );
+  }
 
   return (
     <>
@@ -73,7 +87,7 @@ export default function NotificationList() {
         <div className="max-w-2xl mx-auto w-full">
           <div className="py-6">
             <h1 className="text-xl font-bold text-gray-800 mb-6">공지사항</h1>
-            
+
             <div className="space-y-4">
               {isLoading ? (
                 <div className="bg-white rounded-lg shadow-sm p-8 text-center text-gray-500">
@@ -99,6 +113,8 @@ export default function NotificationList() {
         </div>
       </div>
 
+      <PrivacyPolicyFooter />
+      <BottomSafeSpacer height={64} />
       <FooterNav />
 
       {showDetailModal && selectedNotification && (
@@ -116,13 +132,15 @@ export default function NotificationList() {
                   ✕
                 </button>
               </div>
-              
+
               <div className="mb-4 pb-4 border-b border-gray-200">
                 <div className="flex items-center text-xs text-gray-500 gap-3">
                   <span className="px-2 py-1 bg-blue-100 text-blue-700 rounded-full text-xs font-medium">
                     작성자: 관리자
                   </span>
-                  <span>작성일: {formatDate(selectedNotification.createdAt)}</span>
+                  <span>
+                    작성일: {formatDate(selectedNotification.createdAt)}
+                  </span>
                   <span>조회수: {selectedNotification.viewCount}</span>
                 </div>
               </div>
@@ -151,9 +169,14 @@ export default function NotificationList() {
   );
 }
 
-function UserNotificationCard({ notification, onViewClick, formatDate, truncateContent }) {
+function UserNotificationCard({
+  notification,
+  onViewClick,
+  formatDate,
+  truncateContent,
+}) {
   return (
-    <article 
+    <article
       className="relative rounded-xl border bg-white shadow-sm overflow-hidden transition hover:shadow-md cursor-pointer"
       onClick={() => onViewClick(notification)}
     >

--- a/src/app/suggest/history/[id]/page.jsx
+++ b/src/app/suggest/history/[id]/page.jsx
@@ -3,9 +3,9 @@
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import axiosInstance from '../../../../libs/api/instance';
+import SuggestionImagesByUrl from '../../../../components/admin/SuggestionImagesByUrl';
 import FooterNav from '@components/common/FooterNav';
 import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
-import SuggestionImagesByUrl from '../../../../components/admin/SuggestionImagesByUrl';
 
 const CATEGORIES = ['분실물', '기물파손', '시설고장', '소음공해', '기타'];
 const PLACES = [

--- a/src/app/suggest/history/page.jsx
+++ b/src/app/suggest/history/page.jsx
@@ -6,9 +6,9 @@ import { useRouter } from 'next/navigation';
 import { jwtDecode } from 'jwt-decode';
 import axiosInstance from '../../../libs/api/instance';
 import useTokenStore from '../../../stores/useTokenStore';
+import ThumbByUrl from '../../../components/suggest/ThumbByUrl';
 import FooterNav from '@components/common/FooterNav';
 import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
-import ThumbByUrl from '../../../components/suggest/ThumbByUrl';
 
 function BottomSafeSpacer({ height = 64 }) {
   return (

--- a/src/app/suggest/page.jsx
+++ b/src/app/suggest/page.jsx
@@ -2,10 +2,9 @@
 
 import React, { useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import axiosInstance from '../../libs/api/instance';
 import FooterNav from '@components/common/FooterNav';
 import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
-import axiosInstance from '../../libs/api/instance';
 
 const MAX_TITLE = 20;
 const MAX_CONTENT = 3000;
@@ -40,7 +39,7 @@ function BottomSafeSpacer({ height = 64 }) {
 const bytesToMB = (bytes) => (bytes / (1024 * 1024)).toFixed(1);
 
 export default function SuggestPage() {
-  const router = useRouter();
+  // const router = useRouter();
 
   const [category, setCategory] = useState(categories[0]);
   const [place, setPlace] = useState(places[0]);

--- a/src/components/common/FooterNav.jsx
+++ b/src/components/common/FooterNav.jsx
@@ -26,7 +26,10 @@ const FooterNav = () => {
   return (
     <>
       <footer className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-[600px] flex justify-around items-center p-4 bg-white border-t border-gray-100 z-50">
-        <button className="flex flex-col items-center gap-1 p-2 hover:bg-gray-50 rounded-lg transition-colors group">
+        <button
+          className="flex flex-col items-center gap-1 p-2 hover:bg-gray-50 rounded-lg transition-colors group"
+          onClick={() => router.push('/')}
+        >
           <div className="relative w-6 h-6">
             <img
               src="/static/icons/reservation_icon.svg"

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -2,8 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import InfoModal from './InfoModal';
 import axiosInstance from '../../libs/api/instance';
+import InfoModal from './InfoModal';
 
 const Header = () => {
   const router = useRouter();
@@ -16,7 +16,9 @@ const Header = () => {
 
   const fetchRecentNotificationCount = async () => {
     try {
-      const response = await axiosInstance.get('/api/notification/recent-count');
+      const response = await axiosInstance.get(
+        '/api/notification/recent-count',
+      );
       if (response.data.error) {
         console.error('최근 공지사항 개수 조회 실패:', response.data.error);
         return;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/add-home-button

### 💡 작업개요
-  커뮤니티 전역 페이지와 공지사항 페이지 하단에 PrivacyPolicyFooter → BottomSafeSpacer → FooterNav 순으로 공통 Footer 레이아웃 적용
- `FooterNav.jsx`의 ‘예약하기’ 버튼에 `router.push('/')`를 연결하여 홈으로 즉시 이동하도록 구현

## 🔑 주요 변경사항
## 1) Footer 공통화 (Community/Notice)
- 각 페이지에 아래 Footer 스택 적용:
  - **PrivacyPolicyFooter** (개인정보처리방침 노출)
  - **BottomSafeSpacer** (iOS 등 safe-area 대응, `calc(${height}px + env(safe-area-inset-bottom, 0px))`)
  - **FooterNav** (하단 네비게이션)
- 필요한 곳에 `min-h-screen` 컨테이너 유지/추가 → **하단 고정 영역 잘림 방지**

- import 정리:
  ```javascript
  import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
- (프로젝트 alias에 맞춰 경로 통일)
  
## 2) 홈 이동 동작 추가 (FooterNav)
- FooterNav.jsx의 ‘예약하기’ 버튼에 홈 이동 로직 연결:
```onClick={() => router.push('/')}```
- 페이지 전환 시 상태 보존/리다이렉트 타이밍에 영향 없도록 기존 구조 유지


### 🏞 스크린샷


### 🔗 관련 이슈 
- #182 
