### PR TITLE
[Feat] FooterNav 전역 삽입 및 하단 겹침 이슈 해결

### DIFF
--- a/src/app/login/page.jsx
+++ b/src/app/login/page.jsx
@@ -5,10 +5,20 @@ import Link from 'next/link';
 import { jwtDecode } from 'jwt-decode';
 import Button from '../../components/common/Button';
 import PrivacyPolicyFooter from '../../components/common/PrivacyPolicyFooter';
+import FooterNav from '../../components/common/FooterNav';
 import { isValidPassword, strictEmailRegex } from '../../constants/regex';
 import useTokenStore from '../../stores/useTokenStore';
 import axiosInstance, { setAccessToken } from '../../libs/api/instance';
 import { getLoginErrorMessage } from '../../utils/errorMessages';
+
+function BottomSafeSpacer({ height = 64 }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ height: `calc(${height}px + env(safe-area-inset-bottom, 0px))` }}
+    />
+  );
+}
 
 function LoginForm() {
   const [email, setEmail] = useState('');
@@ -139,6 +149,7 @@ function LoginForm() {
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
+      {/* 본문 */}
       <div className="flex-1 px-6 py-8">
         <div className="text-center space-y-3 mb-8">
           <h1 className="text-2xl font-bold text-[#788cff] tracking-tight">
@@ -245,6 +256,8 @@ function LoginForm() {
       </div>
 
       <PrivacyPolicyFooter />
+      <BottomSafeSpacer height={64} />
+      <FooterNav />
     </div>
   );
 }

--- a/src/app/login/reset-password-step1/page.jsx
+++ b/src/app/login/reset-password-step1/page.jsx
@@ -5,6 +5,16 @@ import { strictEmailRegex } from '../../../constants/regex';
 import axiosInstance from '../../../libs/api/instance';
 import Button from '../../../components/common/Button';
 import PrivacyPolicyFooter from '../../../components/common/PrivacyPolicyFooter';
+import FooterNav from '../../../components/common/FooterNav';
+
+function BottomSafeSpacer({ height = 64 }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ height: `calc(${height}px + env(safe-area-inset-bottom, 0px))` }}
+    />
+  );
+}
 
 export default function ResetPassWord1() {
   const [email, setEmail] = useState('');
@@ -285,6 +295,8 @@ export default function ResetPassWord1() {
       </main>
 
       <PrivacyPolicyFooter />
+      <BottomSafeSpacer height={64} />
+      <FooterNav />
     </div>
   );
 }

--- a/src/app/login/reset-password-step2/page.jsx
+++ b/src/app/login/reset-password-step2/page.jsx
@@ -5,6 +5,16 @@ import { isValidPassword } from '../../../constants/regex';
 import axiosInstance from '../../../libs/api/instance';
 import Button from '../../../components/common/Button';
 import PrivacyPolicyFooter from '../../../components/common/PrivacyPolicyFooter';
+import FooterNav from '../../../components/common/FooterNav';
+
+function BottomSafeSpacer({ height = 64 }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ height: `calc(${height}px + env(safe-area-inset-bottom, 0px))` }}
+    />
+  );
+}
 
 export default function ResetPassword2() {
   const [email, setEmail] = useState('');
@@ -139,6 +149,8 @@ export default function ResetPassword2() {
 
       {/* 푸터: 여백 없이 하단 고정 */}
       <PrivacyPolicyFooter />
+      <BottomSafeSpacer height={64} />
+      <FooterNav />
     </div>
   );
 }

--- a/src/app/login/sign-up-step1/page.jsx
+++ b/src/app/login/sign-up-step1/page.jsx
@@ -7,7 +7,17 @@ import useSignupStore from '../../../stores/useSignupStore';
 import axiosInstance from '../../../libs/api/instance';
 import Button from '../../../components/common/Button';
 import PrivacyPolicyFooter from '../../../components/common/PrivacyPolicyFooter';
+import FooterNav from '../../../components/common/FooterNav';
 import CustomizedStepper from './customizedStepper';
+
+function BottomSafeSpacer({ height = 64 }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ height: `calc(${height}px + env(safe-area-inset-bottom, 0px))` }}
+    />
+  );
+}
 
 export default function SignUpStep1() {
   const router = useRouter();
@@ -328,6 +338,8 @@ export default function SignUpStep1() {
       </div>
 
       <PrivacyPolicyFooter />
+      <BottomSafeSpacer height={64} />
+      <FooterNav />
     </div>
   );
 }

--- a/src/app/login/sign-up-step2/page.jsx
+++ b/src/app/login/sign-up-step2/page.jsx
@@ -5,7 +5,17 @@ import { isValidPassword } from '../../../constants/regex';
 import useSignupStore from '../../../stores/useSignupStore';
 import Button from '../../../components/common/Button';
 import PrivacyPolicyFooter from '../../../components/common/PrivacyPolicyFooter';
+import FooterNav from '../../../components/common/FooterNav';
 import CustomizedStepper from './customizedStepper';
+
+function BottomSafeSpacer({ height = 64 }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ height: `calc(${height}px + env(safe-area-inset-bottom, 0px))` }}
+    />
+  );
+}
 
 export default function SignUpStep2() {
   const router = useRouter();
@@ -121,6 +131,8 @@ export default function SignUpStep2() {
       </main>
 
       <PrivacyPolicyFooter />
+      <BottomSafeSpacer height={64} />
+      <FooterNav />
     </div>
   );
 }

--- a/src/app/login/sign-up-step3/page.jsx
+++ b/src/app/login/sign-up-step3/page.jsx
@@ -5,7 +5,17 @@ import axios from 'axios';
 import useSignupStore from '../../../stores/useSignupStore';
 import Button from '../../../components/common/Button';
 import PrivacyPolicyFooter from '../../../components/common/PrivacyPolicyFooter';
+import FooterNav from '../../../components/common/FooterNav';
 import CustomizedStepper from './customizedStepper';
+
+function BottomSafeSpacer({ height = 64 }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ height: `calc(${height}px + env(safe-area-inset-bottom, 0px))` }}
+    />
+  );
+}
 
 const NAME_DRAFT_KEY = 'signup_name_draft';
 
@@ -180,6 +190,8 @@ export default function SignUpStep3() {
       </main>
 
       <PrivacyPolicyFooter />
+      <BottomSafeSpacer height={64} />
+      <FooterNav />
     </div>
   );
 }

--- a/src/app/login/sign-up-step4/page.jsx
+++ b/src/app/login/sign-up-step4/page.jsx
@@ -4,7 +4,17 @@ import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import Button from '../../../components/common/Button';
 import PrivacyPolicyFooter from '../../../components/common/PrivacyPolicyFooter';
+import FooterNav from '../../../components/common/FooterNav';
 import CustomizedStepper from './customizedStepper';
+
+function BottomSafeSpacer({ height = 64 }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ height: `calc(${height}px + env(safe-area-inset-bottom, 0px))` }}
+    />
+  );
+}
 
 function SignUpStep4() {
   const searchParams = useSearchParams();
@@ -57,6 +67,8 @@ function SignUpStep4() {
       </main>
 
       <PrivacyPolicyFooter />
+      <BottomSafeSpacer height={64} />
+      <FooterNav />
     </div>
   );
 }

--- a/src/app/my/account-info/page.jsx
+++ b/src/app/my/account-info/page.jsx
@@ -9,6 +9,16 @@ import MyPageBlock from '@components/common/MyPageBlock';
 import Modal from '@components/common/Modal';
 import LoginRequiredModal from '@components/common/LoginRequiredModal';
 import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
+import FooterNav from '../../../components/common/FooterNav';
+
+function BottomSafeSpacer({ height = 64 }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ height: `calc(${height}px + env(safe-area-inset-bottom, 0px))` }}
+    />
+  );
+}
 
 export default function AccountInfo() {
   const [open, setOpen] = useState(false);
@@ -293,6 +303,8 @@ export default function AccountInfo() {
       </div>
 
       <PrivacyPolicyFooter />
+      <BottomSafeSpacer height={64} />
+      <FooterNav />
     </div>
   );
 }

--- a/src/app/my/cancel-account-step1/page.jsx
+++ b/src/app/my/cancel-account-step1/page.jsx
@@ -10,6 +10,16 @@ import PrivacyPolicyFooter from '../../../components/common/PrivacyPolicyFooter'
 import MyPageHeader from '@components/common/MyPageHeader';
 import Modal from '@components/common/Modal';
 import LoginRequiredModal from '@components/common/LoginRequiredModal';
+import FooterNav from '../../../components/common/FooterNav';
+
+function BottomSafeSpacer({ height = 64 }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ height: `calc(${height}px + env(safe-area-inset-bottom, 0px))` }}
+    />
+  );
+}
 
 export default function CancelAccountStep1() {
   const [open, setOpen] = useState(false);
@@ -186,6 +196,8 @@ export default function CancelAccountStep1() {
         </main>
 
         <PrivacyPolicyFooter />
+        <BottomSafeSpacer height={64} />
+        <FooterNav />
       </div>
 
       <LoginRequiredModal

--- a/src/app/my/cancel-account-step2/page.jsx
+++ b/src/app/my/cancel-account-step2/page.jsx
@@ -3,6 +3,16 @@ import React from 'react';
 import Link from 'next/link';
 import Button from '../../../components/common/Button';
 import PrivacyPolicyFooter from '../../../components/common/PrivacyPolicyFooter';
+import FooterNav from '../../../components/common/FooterNav';
+
+function BottomSafeSpacer({ height = 64 }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ height: `calc(${height}px + env(safe-area-inset-bottom, 0px))` }}
+    />
+  );
+}
 
 export default function CancelAccountStep2() {
   const handleCancelAccount = () => {
@@ -34,6 +44,8 @@ export default function CancelAccountStep2() {
       </main>
 
       <PrivacyPolicyFooter />
+      <BottomSafeSpacer height={64} />
+      <FooterNav />
     </div>
   );
 }

--- a/src/app/my/comments/page.jsx
+++ b/src/app/my/comments/page.jsx
@@ -8,6 +8,16 @@ import MyPageHeader from '@components/common/MyPageHeader';
 import LoginRequiredModal from '@components/common/LoginRequiredModal';
 import Modal from '@components/common/Modal';
 import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
+import FooterNav from '../../../components/common/FooterNav';
+
+function BottomSafeSpacer({ height = 64 }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ height: `calc(${height}px + env(safe-area-inset-bottom, 0px))` }}
+    />
+  );
+}
 
 export default function MyCommentsPage() {
   const [comments, setComments] = useState([]);
@@ -199,6 +209,8 @@ export default function MyCommentsPage() {
       />
 
       <PrivacyPolicyFooter />
+      <BottomSafeSpacer height={64} />
+      <FooterNav />
     </div>
   );
 }

--- a/src/app/my/posts/page.jsx
+++ b/src/app/my/posts/page.jsx
@@ -8,6 +8,16 @@ import MyPageHeader from '@components/common/MyPageHeader';
 import LoginRequiredModal from '@components/common/LoginRequiredModal';
 import Modal from '@components/common/Modal';
 import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
+import FooterNav from '../../../components/common/FooterNav';
+
+function BottomSafeSpacer({ height = 64 }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ height: `calc(${height}px + env(safe-area-inset-bottom, 0px))` }}
+    />
+  );
+}
 
 export default function MyPostsPage() {
   const [posts, setPosts] = useState([]);
@@ -208,6 +218,8 @@ export default function MyPostsPage() {
       />
 
       <PrivacyPolicyFooter />
+      <BottomSafeSpacer height={64} />
+      <FooterNav />
     </div>
   );
 }

--- a/src/app/my/reservation-list/page.jsx
+++ b/src/app/my/reservation-list/page.jsx
@@ -6,6 +6,16 @@ import MyPageHeader from '@components/common/MyPageHeader';
 import ReservationList from '@components/common/ReservationList';
 import LoginRequiredModal from '@components/common/LoginRequiredModal';
 import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
+import FooterNav from '../../../components/common/FooterNav';
+
+function BottomSafeSpacer({ height = 64 }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ height: `calc(${height}px + env(safe-area-inset-bottom, 0px))` }}
+    />
+  );
+}
 
 export default function ReservationInfo() {
   const [showLoginModal, setShowLoginModal] = useState(false);
@@ -42,6 +52,8 @@ export default function ReservationInfo() {
       />
 
       <PrivacyPolicyFooter />
+      <BottomSafeSpacer height={64} />
+      <FooterNav />
     </div>
   );
 }

--- a/src/app/my/reset-name/page.jsx
+++ b/src/app/my/reset-name/page.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { useRouter } from 'next/navigation';
+import FooterNav from '../../../components/common/FooterNav';
 
 export default function ResetName() {
   const router = useRouter();
@@ -10,5 +11,9 @@ export default function ResetName() {
     router.replace('/my/account-info');
   }, [router]);
 
-  return null;
+  return (
+    <>
+      <FooterNav />
+    </>
+  );
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/add-global-footer

### 💡 작업개요
- 서비스 전반의 하단 네비게이션을 통일하기 위해 FooterNav를 전역적으로 삽입하고, PrivacyPolicyFooter(정책 영역)와의 겹침/가림 문제 해결
- 또한 이용약관/개인정보처리방침/이메일 인증 안내 페이지는 예외로 두어 FooterNav 미렌더링

## 🔑 주요 변경사항
### 1) 공통 레이아웃 패턴 도입
- 각 페이지 최상위 컨테이너를 `min-h-screen flex flex-col`로 통일
- 본문 컨테이너는 `flex-1`로 지정해 화면 높이 전체에서 안전하게 스크롤/배치
- 비즈니스 로직/상태/이벤트 핸들러 변경 없음

```jsx
<div className="min-h-screen flex flex-col">
  <main className="flex-1">{/* ...page content... */}</main>
  {/* 하단 영역 (정책 → 안전여백 → FooterNav) */}
</div>
```

### 2) 하단 렌더 순서 통일 (겹침 방지)
- `FooterNav`가 `fixed` 되는 특성상, 상단 콘텐츠 또는 `PrivacyPolicyFooter`가 가려지는 현상 방지
- **렌더 순서 표준화**:  
  `PrivacyPolicyFooter` → `BottomSafeSpacer` → `FooterNav`

```jsx
<PrivacyPolicyFooter />
<BottomSafeSpacer height={64} />
<FooterNav active="..." />
```

### 3) 안전 여백 컴포넌트 적용 (`BottomSafeSpacer`)
- iOS 노치/홈 인디케이터 환경에서 하단 안전영역 확보
- 건의하기 페이지의 구현을 참고/재사용 (중복 정의 시 가장 인접 파일에 로컬 정의)

```jsx
function BottomSafeSpacer({ height = 64 }) {
  return (
    <div
      aria-hidden="true"
      style={{ height: `calc(${height}px + env(safe-area-inset-bottom, 0px))` }}
    />
  );
}
```

### 4) 예외 페이지 분기
- `FooterNav` 미노출 페이지:
  - 이용약관 페이지
  - 개인정보처리방침 페이지
  - 이메일 인증 안내 페이지
- 라우트/컴포넌트 이름은 현행 구조 유지  
- 조건부 렌더링 또는 해당 페이지에서 `FooterNav` 삽입 생략

---

### 5) `FooterNav` 활성 탭(`active` prop) 기존 값 유지
- 각 페이지가 지정하던 `active` 값 변경 없이 그대로 사용
- 시맨틱/접근성 영향 없음


### 🏞 스크린샷


### 🔗 관련 이슈 
- #196