### PR TITLE
[Fix] 로그아웃 요청 Endpoint 수정 및 프로덕션 콘솔 출력 제거

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,13 +3,16 @@ const path = require('path');
 
 const isProd = process.env.NODE_ENV === 'production';
 
-module.exports = {
+const nextConfig = {
   pageExtensions: ['js', 'jsx', 'html'],
 
-  // 프로덕션 빌드에서만 console 제거 (error는 유지)
+  // 프로덕션 빌드에서 모든 console.* 제거
   compiler: {
-    removeConsole: isProd ? { exclude: ['error'] } : false,
+    removeConsole: isProd,
   },
+
+  // 프로덕션에서 소스맵 노출 방지
+  productionBrowserSourceMaps: false,
 
   experimental: {
     turbo: {
@@ -40,3 +43,5 @@ module.exports = {
     return config;
   },
 };
+
+module.exports = nextConfig;

--- a/src/app/my/account-info/page.jsx
+++ b/src/app/my/account-info/page.jsx
@@ -114,8 +114,15 @@ export default function AccountInfo() {
 
   const handleLogout = async () => {
     try {
-      await axiosInstance.post('/auth/logout');
+      await axiosInstance.post('/logout', null, {
+        withCredentials: true,
+      });
     } catch (error) {
+      if (error?.response?.status === 403) {
+        console.warn(
+          'CSRF 검증 실패로 로그아웃이 거부되었습니다. 쿠키/도메인/HTTPS/CORS 설정을 확인하세요.',
+        );
+      }
       console.error('로그아웃 API 호출 실패:', error);
     } finally {
       clearTokens();
@@ -235,8 +242,6 @@ export default function AccountInfo() {
         onClose={() => setOpen(false)}
         onSubmit={handleUsernameChange}
         text={submitting ? '수정 중…' : '수정'}
-        // Modal 컴포넌트가 지원한다면 disabled 전파 권장:
-        // disabled={submitting || !newName.trim() || newName.trim() === (userInfo.name || '')}
       >
         <div className="p-6 space-y-6">
           <div className="text-center">


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/logout-endpoint-path

### 💡 작업개요
- 실서비스 배포 환경에서 console 전면 제거로 로그 노이즈를 없앰
- `admin/dashboard` 페이지에서 함수 초기화 순서 문제(TDZ) 로 발생하던 `ReferenceError` 해결
- `my/account-info` 페이지의 로그아웃 요청 경로/자격증명 처리 보강으로 403 및 불안정 동작을 완화

## 🔑 주요 변경사항
## 1) 빌드 설정 — `next.config.js`
- **SWC removeConsole 적용**: `compiler.removeConsole`을 **프로덕션에서 전면 활성화**하여 *에러 포함 모든* `console.*` 호출 제거
- **소스맵 비활성화**: `productionBrowserSourceMaps: false`로 설정해 프로덕션에서 소스 노출 최소화
- **기존 설정 유지**: Webpack **alias**, **SVG 로더**, **Turbo** 규칙은 현행대로 유지

---

## 2) 관리자 대시보드 — `src/app/admin/dashboard/page.jsx`
- **콜백 참조 안정화**: `fetchReservations`, `fetchCommunityData`, `fetchSuggestionsData`, `fetchRoomData`를 `useCallback`으로 **상단에 선언**
- **의존성 주입 정정**: `useEffect` 의존성 배열에 위 콜백을 주입해 **재생성 방지** 및 `ReferenceError: Cannot access 'fetchCommunityData' before initialization` 해소
- **리스너/폴링 최적화**: 인터벌/이벤트 리스너에서도 **동일 콜백 참조를 재사용**하여 중복 호출 및 메모리 누수 방지

---

## 3) 마이페이지(로그아웃) — `src/app/my/account-info/page.jsx`
- **엔드포인트 고정**: 로그아웃 요청을 `POST /logout`으로 통일
- **자격증명 전송 보장**: 호출 시 `withCredentials: true`로 **쿠키/CSRF 연동** 지원(403 완화)
- **클라이언트 상태 정리**: 실패하더라도 **토큰/세션 정리** 및 **완료 모달** 흐름 유지
- **로그 정책 정합**: 운영 환경에서 `removeConsole` 정책으로 **에러 로그 출력 없음**


### 🏞 스크린샷


### 🔗 관련 이슈 
- #200 