### PR TITLE
[Feat] 건의/신고 페이지 카테고리 라벨 정규화

### DIFF
--- a/src/app/suggest/page.jsx
+++ b/src/app/suggest/page.jsx
@@ -11,7 +11,14 @@ const MAX_CONTENT = 3000;
 const MAX_FILES = 5;
 const MAX_TOTAL_SIZE = 30 * 1024 * 1024;
 
-const categories = ['분실물', '기물파손', '시설고장', '소음공해', '기타'];
+const categories = [
+  '분실물',
+  '기물 파손',
+  '시설 고장',
+  '소음 공해',
+  '미예약 사용자 신고',
+  '기타',
+];
 const places = [
   '스터디룸 1',
   '스터디룸 2',


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/community-plus-icon-position

### 💡 작업개요
- 건의/신고 내역 페이지에서 서버 응답이 배열이 아닐 경우 `.map()` 호출 시 오류가 발생하던 문제 해결
- API 응답을 항상 배열로 정규화하도록 보강하고, 권한 오류(403)나 데이터 없음(404) 응답 시에도 빈 상태를 안전하게 처리하도록 개선
- 사용자 경험 측면에서는 건의/신고 내역이 없을 때 안내 문구("등록된 건의/신고 내역이 없습니다.")가 노출되도록 하여 UI/UX의 완결성 강화


## 🔑 주요 변경사항
1. **카테고리 상수 값 일치화**
   - 파일: `src/app/suggest/page.jsx`
   - `const categories` 라벨에서 단어간 띄어쓰기를 하여 서버 enum과 **1:1로 동일**하게 맞춤
   - 드롭다운 `<select>`는 동일 배열을 사용하므로 별도 매핑 로직 없이 일관성 유지


### 🏞 스크린샷

### 🔗 관련 이슈 
- #204 