### PR TITLE
[Fix] 회원가입 페이지 로딩 모달 표시 시 FooterNav 블러 미적용 문제 수정

### DIFF
--- a/src/app/login/sign-up-step1/page.jsx
+++ b/src/app/login/sign-up-step1/page.jsx
@@ -172,7 +172,7 @@ export default function SignUpStep1() {
     <div className="min-h-screen bg-gray-50 flex flex-col">
       {isSending && (
         <div
-          className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center"
+          className="fixed inset-0 z-[9999] bg-black/40 backdrop-blur-sm md:backdrop-blur flex items-center justify-center"
           role="status"
           aria-live="polite"
         >


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/signup-step1-footer-blur

### 💡 작업개요
- 회원가입 1단계(SignUpStep1)에서 인증 메일 전송 중 표시되는 로딩 모달이 떠도, 하단 고정 내비게이션(FooterNav)이 선명하게 보이는 문제 존재
- **오버레이 레이어의 z-index가 충분히 높지 않고(backdrop-filter 미사용)**, `FooterNav`가 고정(fixed)로 떠 있는 레이어 위에 블러가 적용되지 않았기 때문
- **오버레이 z-index 상향**과 **`backdrop-blur` 적용**으로 모달 표시 시 화면 전체(고정 요소 포함)에 일관된 블러가 적용되도록 수정


## 🔑 주요 변경사항
1. **오버레이 레이어 상향 및 블러 활성화**
   - `z-50` → `z-[9999]`로 상향하여 모든 고정 레이어(FooterNav 등) 위에 오버레이가 렌더링되도록 보장
   - `bg-black bg-opacity-50` → `bg-black/40`로 투명도 유지 (블러 시 시각적으로 더 자연스러움)
   - `backdrop-blur-sm md:backdrop-blur` 추가로 **화면 전체 배경 블러** 적용  
     ↳ 블러는 지원 브라우저에서만 활성화되며, 미지원 환경에서는 기존의 반투명 오버레이로 안전하게 폴백

2. **접근성(ARIA) 유지**
   - `role="status"`, `aria-live="polite"` 유지 → 로딩 상태를 보조기기에서 인지 가능
   - DOM 구조 변경 없음, **상호작용 차단은 오버레이 전체 커버로 해결** (추가 스크립트 불필요)
   
### 🏞 스크린샷

### 🔗 관련 이슈 
- #208 