### PR TITLE
[Fix] 모바일 협소 화면에서 커뮤니티 댓글 ‘등록’ 버튼 텍스트 세로줄바꿈 이슈 수정

### DIFF
--- a/src/components/community/CommentItem.jsx
+++ b/src/components/community/CommentItem.jsx
@@ -125,14 +125,14 @@ const CommentItem = ({
               value={replyContent}
               onChange={(e) => setReplyContent(e.target.value)}
               placeholder="대댓글을 입력하세요..."
-              className="flex-1 rounded-md border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:border-[#788DFF] focus:ring-[#788DFF]/20"
+              className="flex-1 min-w-0 rounded-md border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:border-[#788DFF] focus:ring-[#788DFF]/20"
               disabled={isSubmitting}
               maxLength={300}
             />
             <button
               onClick={handleReplySubmit}
               disabled={!replyContent.trim() || isSubmitting}
-              className="px-3 py-2 rounded-md text-sm text-white bg-[#788DFF] hover:bg-[#6177ff] disabled:bg-gray-300"
+              className="shrink-0 whitespace-nowrap min-w-[56px] px-3 py-2 rounded-md text-sm text-white bg-[#788DFF] hover:bg-[#6177ff] disabled:bg-gray-300"
             >
               등록
             </button>


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/mobile-comment-button

### 💡 작업개요
- 일부 모바일 기기(폭이 좁은 단말)에서 댓글 입력 영역의 **‘등록’ 버튼 텍스트가 세로로 줄바꿈**되는 문제 발생
- 부모 컨테이너의 `flex` 수축 흐름을 조정하여 **버튼은 고정 폭/가로표시 유지**, **입력창이 먼저 줄어들도록** 처리

## 🔑 주요 변경사항
1) **Flex 수축 우선순위 수정**
   - 입력창에 `min-w-0` 추가  
     - 기본적으로 flex item은 콘텐츠 폭을 보존하려고 하여 버튼이 먼저 찌부되던 문제를 해소
     - 협소 화면에서 입력창이 먼저 수축하도록 명시
2) **버튼 줄바꿈 및 폭 수축 방지**
   - 버튼에 `shrink-0` 적용 → flex 수축에서 제외
   - 버튼에 `whitespace-nowrap` 적용 → 텍스트 줄바꿈 금지
   - 버튼에 `min-w-[56px]` 적용 → 초소형 화면에서도 가로표시를 보장하는 최소 폭 확보
   
### 🏞 스크린샷
- 전
<img width="295" height="727" alt="image" src="https://github.com/user-attachments/assets/f6193db6-b6bf-41df-b105-33092ca4c260" />

-후
<img width="300" height="727" alt="image" src="https://github.com/user-attachments/assets/c7c5a200-370c-4a84-8c92-7959cd9564f2" />


### 🔗 관련 이슈 
- #215