### PR TITLE
[Style] 건의/신고 페이지, 예약 내역 모바일 UI 개선

### DIFF
--- a/src/app/suggest/history/page.jsx
+++ b/src/app/suggest/history/page.jsx
@@ -174,7 +174,7 @@ function StatusBadge({ status }) {
   const isDone = !!status;
   return (
     <span
-      className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs ${
+      className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs flex-shrink-0 whitespace-nowrap ${
         isDone
           ? 'bg-[#eef2ff] text-[var(--primary-color)]'
           : 'bg-[#f4f4f5] text-[var(--text-muted)]'
@@ -215,7 +215,7 @@ function HistoryCard({ item }) {
 
           <div className="flex-1 min-w-0">
             <div className="flex items-start justify-between gap-2">
-              <h3 className="text-[16px] leading-6 font-medium text-[var(--text-primary)] truncate">
+              <h3 className="flex-1 min-w-0 text-[16px] leading-6 font-medium text-[var(--text-primary)] truncate">
                 {title}
               </h3>
               <StatusBadge status={isAnswered} />

--- a/src/components/common/AfterLoginBanner.jsx
+++ b/src/components/common/AfterLoginBanner.jsx
@@ -99,7 +99,7 @@ const AfterLoginBanner = () => {
           내가 예약한 방
         </div>
 
-        {/* 예약 리스트 영역 (스크롤) */}
+        {/* 예약 리스트 영역 */}
         <div className="flex flex-col gap-2 sm:gap-3 overflow-y-auto pr-1 sm:pr-2 flex-1 max-h-48">
           {!Array.isArray(userReservations) || userReservations.length === 0 ? (
             <div className="flex items-center justify-center h-full text-[#9b9998] text-xs sm:text-sm">
@@ -111,21 +111,23 @@ const AfterLoginBanner = () => {
                 key={r.id}
                 className="flex justify-between items-center p-2 sm:p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors"
               >
-                <div className="flex flex-col gap-1 flex-1 min-w-0 mr-2 sm:mr-3">
-                  <div className="text-xs text-[#73726e] whitespace-nowrap overflow-hidden text-ellipsis">
+                <div className="flex flex-col gap-1 flex-1 min-w-0 mr-2 sm:mr-3 overflow-x-auto sm:overflow-x-visible xScrollHide">
+                  <div className="text-xs text-[#73726e] whitespace-nowrap sm:overflow-hidden sm:text-ellipsis">
                     {r.roomName}
                   </div>
-                  <div className="text-xs sm:text-sm font-medium text-[#37352f] whitespace-nowrap overflow-hidden text-ellipsis">
+                  <div className="text-xs sm:text-sm font-medium text-[#37352f] whitespace-nowrap sm:overflow-hidden sm:text-ellipsis">
                     {formatDate(r.startTime)} {formatTime(r.startTime)} ~{' '}
                     {formatTime(r.endTime)}
                   </div>
                 </div>
+
                 <button
                   className="flex-shrink-0 px-2 sm:px-3 py-1 sm:py-1.5 text-xs font-medium text-[#788DFF] hover:bg-[#788DFF] hover:text-white rounded-md transition-colors whitespace-nowrap"
                   onClick={() => setOpenReservationId(r.id)}
                 >
                   취소
                 </button>
+
                 <CancellationModal
                   isOpen={openReservationId === r.id}
                   onClose={() => setOpenReservationId(null)}
@@ -156,6 +158,16 @@ const AfterLoginBanner = () => {
           )}
         </div>
       </div>
+
+      <style jsx>{`
+        .xScrollHide::-webkit-scrollbar {
+          display: none;
+        }
+        .xScrollHide {
+          -ms-overflow-style: none; /* IE/Edge */
+          scrollbar-width: none; /* Firefox */
+        }
+      `}</style>
     </div>
   );
 };


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- style/ui-reservation-time-portrait

### 💡 작업개요
- 모바일 환경에서 가독성이 떨어지던 UI 개선
 - 예약 내역(AfterLoginBanner): 모바일 세로 모드에서 예약 시간이 잘려 보이는 문제 해결  
 - 건의/신고 내역(SuggestHistoryPage): 뱃지 텍스트가 줄바꿈되는 문제 수정  

## 🔑 주요 변경사항
- **AfterLoginBanner**
  - 예약 내역 항목에 모바일 전용 `overflow-x-auto` 적용 → 좌우 스와이프 시 예약 시간을 끝까지 확인 가능  
  - `styled-jsx` 로컬 스타일을 사용해 **스크롤바는 안보이도록 구현**

- **건의/신고 내역 페이지**
  - `StatusBadge`에 `flex-shrink-0 whitespace-nowrap` 추가 → 모바일에서도 `답변완료`/`답변대기중` 뱃지가 줄바꿈되지 않고 항상 한 줄 유지  
  - 제목 `<h3>`에 `flex-1 min-w-0 truncate` 적용 → 공간 부족 시 제목이 우선적으로 줄임표 처리되도록 개선  

   
### 🏞 스크린샷
- 건의/신고 내역 수정 전
<img width="333" height="720" alt="Image" src="https://github.com/user-attachments/assets/6e04b7f5-ff86-4d9a-997e-0e8815f45293" />

- 건의/신고 내역 수정 후
<img width="333" height="720" alt="image" src="https://github.com/user-attachments/assets/84d30c69-aeb6-43b9-a9af-56cfbc24c4e3" />



### 🔗 관련 이슈 
- #219 #220 