### PR TITLE
[Fix] JWT 기반 userId 타입 불일치로 인한 예약 취소 권한 오류 수정

### DIFF
--- a/src/components/common/ReservationList.jsx
+++ b/src/components/common/ReservationList.jsx
@@ -57,14 +57,13 @@ export default function ReservationList() {
   const [groupedReservations, setGroupedReservations] = useState({});
   const [loading, setLoading] = useState(true);
   const [cancelModalData, setCancelModalData] = useState(null);
-  const [authReady, setAuthReady] = useState(false); // ✅ 준비 플래그
+  const [authReady, setAuthReady] = useState(false);
 
   // 첫 마운트 시 세션 값을 스토어로 강제 동기화
   useEffect(() => {
     if (typeof rehydrate === 'function') {
       rehydrate();
     }
-    // 로그인 후 리다이렉트 시 토큰 동기화를 위해 더 긴 지연시간 설정
     const t = setTimeout(() => setAuthReady(true), 100);
     return () => clearTimeout(t);
   }, [rehydrate]);
@@ -75,7 +74,9 @@ export default function ReservationList() {
     if (!accessToken) return null;
     try {
       const d = jwtDecode(accessToken);
-      return d?.userId ?? d?.id ?? d?.uid ?? d?.sub ?? null;
+      const extractedId = d?.userId ?? d?.id ?? d?.uid ?? d?.sub ?? null;
+      // 타입 일관성을 위해 숫자로 변환 (sessionStorage에서 가져온 userId와 동일한 타입으로)
+      return extractedId ? parseInt(extractedId) : null;
     } catch {
       return null;
     }
@@ -100,7 +101,6 @@ export default function ReservationList() {
     async (uid) => {
       try {
         setLoading(true);
-        // 캐시 우회 파라미터로 최초 빈 응답/재사용 방지
         const res = await axiosInstance.get(
           `/api/reservations/user/${uid}?t=${Date.now()}`,
         );


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/reservation-cancel-ownership-check

### 💡 작업개요
- **문제**: 로그인 직후 예약 → 취소 시, 드물게 “본인의 예약만 취소할 수 있습니다.”라는 오류 메세지 발생
- **원인**: `sessionStorage`의 `userId`는 `parseInt()`로 숫자 보관, JWT의 `userId`는 문자열일 수 있음 → 백엔드에서 `===` 비교 시 타입 불일치로 거절
- **해결**: JWT 디코딩 결과의 `userId`를 **항상 `Number(...)`로 변환**하여 일관된 숫자형으로 유지

## 🔑 주요 변경사항
1. **JWT 디코딩 시 userId 정규화**
   - 디코딩 결과에서 `userId | id | uid | sub` 후보 값을 취합 후, **`Number(...)` 캐스팅**으로 숫자형 일치
   - 숫자로 변환 불가능한 경우(`NaN`)는 `null` 처리하여 오작동 방지

   ```ts
   // 변경 전 (문자열 가능)
   const tokenUserId = d?.userId ?? d?.id ?? d?.uid ?? d?.sub ?? null;

   // 변경 후 (항상 숫자형, 실패 시 null)
   const rawUserId = d?.userId ?? d?.id ?? d?.uid ?? d?.sub ?? null;
   const normalizedUserId =
     rawUserId !== null && rawUserId !== undefined && !Number.isNaN(Number(rawUserId))
       ? Number(rawUserId)
       : null;

2. 두 화면의 resolvedUserId 일관화
    - `AfterLoginBanner.jsx` / `ReservationList.jsx` 내 `resolvedUserId` 계산 로직에서 숫자형 보장
    - 백엔드로 전달되는 모든 userId 관련 비교/식별이 숫자 기준으로만 이뤄지도록 통일

   
### 🏞 스크린샷
- 서비스 건의 내역
<img width="335" height="719" alt="image" src="https://github.com/user-attachments/assets/7e526722-1ca8-44c3-b679-3eb37f6bf58d" />
<img width="333" height="719" alt="image" src="https://github.com/user-attachments/assets/4a4f5c3f-d445-4414-90f6-0f7fcaac0565" />

### 🔗 관련 이슈 
- #226