### PR TITLE
[Refactor] 홈(예약화면) 초기 렌더 성능 개선 (LCP 안정화, TBT 감소)

### DIFF
--- a/src/components/common/Banner.jsx
+++ b/src/components/common/Banner.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 
 const Banner = () => {
   return (
@@ -15,25 +16,36 @@ const Banner = () => {
             여유로움
           </div>
         </div>
+
         <div className="space-y-3">
           <div className="text-[#37352f] text-sm leading-relaxed">
             로그인하여 자리를 예약해보세요!
           </div>
-          <Link href="/login">
+
+          <Link href="/login" className="inline-block">
             <button className="flex items-center gap-2 px-4 py-2 bg-[#5B72EE] text-white text-sm font-medium rounded-lg hover:bg-[#4f63d1] transition-colors shadow-sm">
               로그인
-              <img
-                src="/static/icons/arrow_right_icon.svg"
-                alt="arrow"
-                className="w-4 h-4 filter brightness-0 invert"
-              />
+              <span aria-hidden="true" className="w-4 h-4">
+                <Image
+                  src="/static/icons/arrow_right_icon.svg"
+                  alt=""
+                  width={16}
+                  height={16}
+                  className="filter brightness-0 invert"
+                />
+              </span>
             </button>
           </Link>
         </div>
       </div>
-      <img
+
+      <Image
         src="/static/icons/maru_icon.png"
         alt="maru"
+        width={128}
+        height={128}
+        priority
+        sizes="128px"
         className="w-32 h-32 object-contain"
       />
     </div>

--- a/src/components/common/ReservationComponent.jsx
+++ b/src/components/common/ReservationComponent.jsx
@@ -88,12 +88,6 @@ const ReservationComponent = ({ index, roomId }) => {
     return slots;
   }, []);
 
-  useEffect(() => {
-    fetchAllReservedTimes();
-    const interval = setInterval(fetchAllReservedTimes, 10000);
-    return () => clearInterval(interval);
-  }, [fetchAllReservedTimes]);
-
   // 특정 구간이 예약과 충돌하는지 검사 (start 포함, end 제외)
   const isRangeAvailable = (startISO, endISO) => {
     const start = new Date(startISO);

--- a/src/components/common/ReservationSection.jsx
+++ b/src/components/common/ReservationSection.jsx
@@ -1,14 +1,20 @@
-import { useState } from 'react';
+'use client';
+
+import { useEffect, useState } from 'react';
 import TodayReservationList from '@components/common/TodayReservationList';
 import TomorrowReservationList from '@components/common/TomorrowReservationList';
+import useReservationStore from '../../stores/useReservationStore';
 
 const ReservationSection = () => {
   const [currentTab, setTab] = useState(0);
 
-  const menuArr = [
-    { name: '오늘 예약하기', content: <TodayReservationList /> },
-    { name: '내일 예약하기', content: <TomorrowReservationList /> },
-  ];
+  const { fetchAllReservedTimes } = useReservationStore();
+
+  useEffect(() => {
+    fetchAllReservedTimes();
+    const intervalId = setInterval(fetchAllReservedTimes, 10000);
+    return () => clearInterval(intervalId);
+  }, [fetchAllReservedTimes]);
 
   const selectMenuHandler = (index) => {
     setTab(index);
@@ -17,20 +23,24 @@ const ReservationSection = () => {
   return (
     <div className="flex flex-col justify-center items-center bg-white w-full h-auto mt-2 rounded-t-2xl">
       <div className="flex w-full">
-        {menuArr.map((tap, index) => {
-          return (
+        {[{ name: '오늘 예약하기' }, { name: '내일 예약하기' }].map(
+          (tap, index) => (
             <div
               key={index}
-              className={`flex-1 text-center p-4 cursor-pointer transition-all duration-300 ${currentTab === index ? 'text-gray-800 font-medium border-b-2 border-[#788cff] bg-transparent' : 'text-gray-500 font-normal border-b-2 border-transparent bg-transparent hover:text-gray-700'}`}
+              className={`flex-1 text-center p-4 cursor-pointer transition-all duration-300 ${
+                currentTab === index
+                  ? 'text-gray-800 font-medium border-b-2 border-[#788cff] bg-transparent'
+                  : 'text-gray-500 font-normal border-b-2 border-transparent bg-transparent hover:text-gray-700'
+              }`}
               onClick={() => selectMenuHandler(index)}
             >
               {tap.name}
             </div>
-          );
-        })}
+          ),
+        )}
       </div>
-      <div></div>
-      <div className="w-full flex justify-center items-center ">
+
+      <div className="w-full flex justify-center items-center">
         <div className="w-full max-w-[95%]">
           <div style={{ display: currentTab === 0 ? 'block' : 'none' }}>
             <TodayReservationList />

--- a/src/components/common/TomorrowReservationComponent.jsx
+++ b/src/components/common/TomorrowReservationComponent.jsx
@@ -60,12 +60,6 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
     day: 'numeric',
   });
 
-  useEffect(() => {
-    fetchAllReservedTimes();
-    const interval = setInterval(fetchAllReservedTimes, 10000);
-    return () => clearInterval(interval);
-  }, [fetchAllReservedTimes]);
-
   // 예약된 10분 슬롯 키 집합 (빠른 충돌 판정을 위해)
   const reserved10mKeys = useMemo(() => {
     const reservedTimeSlots = reservedTimeSlotsByRoom?.[roomId] || [];


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- refactor/performance-optimization

### 💡 작업개요
홈 화면과 예약 영역의 **초기 렌더링 성능을 개선**하기 위한 작업을 진행했습니다. 
기존 Lighthouse 측정 결과에서는 Performance 점수가 40점대까지 하락하는 케이스가 있었고, 주요 원인은 **LCP 지연과 과도한 TBT(Total Blocking Time)**로 확인되었습니다.

특히 초기 상태에서는
- 상단 배너 이미지가 LCP 요소로 잡히면서 **최대 16초 이상 늦게 렌더링**되었고
- 예약 섹션이 초기 진입 시 함께 로드되며,
- 탭 구조상 보이지 않는 예약 컴포넌트까지 마운트된 상태로 유지되어 **불필요한 렌더링/계산/이펙트 실행이 메인 스레드를 장시간 점유**하고 있었습니다.

이번 작업에서는 성능 병목을 한 번에 모두 해결하기보다는,
- **시각적 렌더링(LCP) 문제를 먼저 해결**하고
- 이후 **초기 JS 실행 비용(TBT)을 단계적으로 줄이는 방향**으로 개선을 진행했습니다.

그 결과 Lighthouse 기준으로
- **LCP: 16.7s → 1.5s**
- **TBT: 14,820ms → 3,320ms (약 78% 감소)**
- **Performance: 42 → 69**
로 성능이 유의미하게 개선되었습니다.


### 🔑 주요 변경사항
#### 1. LCP 개선: 배너 이미지 최적화
Lighthouse 분석 결과, 상단 배너 이미지가 **Largest Contentful Paint(LCP) 요소**로 식별되었습니다.
기존에는 이미지 최적화가 충분히 적용되지 않아, 네트워크 및 렌더 타이밍에 따라 LCP가 크게 지연되는 문제가 있었습니다.

이를 해결하기 위해 배너 이미지를 `Next/Image`로 전환하고, **LCP 후보 이미지에만 `priority` 옵션을 제한적으로 적용**했습니다.
```jsx
<Image
  src="/static/icons/maru_icon.png"
  alt="banner image"
  width={128}
  height={128}
  priority
/>
```
이를 통해 상단 시각적 요소가 초기 로딩 단계에서 우선적으로 로드되도록 하여, “첫 화면이 늦게 뜨는 문제”를 우선적으로 해소했습니다.

#### 2. 초기 렌더 부담 감소: ReservationSection dynamic import
예약 섹션은 타임슬롯 렌더링, 상태 관리, 계산 로직이 많아 **렌더 비용이 큰 컴포넌트**입니다.
그럼에도 기존 구조에서는 홈 진입 시 해당 컴포넌트가 초기 번들에 포함되어 로드되며 TBT 증가의 주요 원인이 되고 있었습니다.

이를 개선하기 위해 `next/dynamic`을 사용하여 예약 섹션을 동적 로딩하도록 변경했습니다.
```jsx
import dynamic from 'next/dynamic';

const ReservationSection = dynamic(
  () => import('@components/common/ReservationSection'),
  {
    ssr: false,
    loading: () => (
      <div className="w-full min-h-[240px] rounded-2xl bg-white" />
    ),
  },
);
```
초기 화면에 반드시 필요하지 않은 영역을 분리함으로써
- 초기 JS 실행 부담을 줄이고
- 메인 스레드 점유 시간을 감소시키는 효과를 얻었습니다.

#### 3. 숨겨진 렌더링 제거: ReservationSection 탭 구조 최적화
기존 ReservationSection 탭 구조는 `display: none` 방식으로 탭을 전환하고 있었기 때문에, 보이지 않는 탭도 **마운트된 상태로 유지**되며 내부 렌더/계산/이펙트가 실행되고 있었습니다.

이를 조건부 렌더링 방식으로 변경하여, 현재 활성화된 탭만 렌더링되도록 구조를 수정했습니다.
```jsx
{currentTab === 0
  ? <TodayReservationList />
  : <TomorrowReservationList />}
```
 해당 변경을 통해
- 비활성 탭 컴포넌트는 완전히 언마운트되고
- 불필요한 계산과 이펙트 실행이 제거되어
TBT 감소 및 탭 전환 시 체감 성능이 개선되었습니다.

#### 4. 예약 슬롯 계산 비용 최적화
예약 시간 슬롯은 10분 단위로 매우 많아, 렌더링 과정에서 “예약 여부 판단”이 반복되면 비용이 커질 수 있는 구조였습니다.

이를 개선하기 위해
- 예약 정보를 **roomId 단위로 분리**하고
-  10분 단위 기준 키(`slotKey10m`)를 생성하여
- `Set` 기반으로 예약 여부를 O(1)로 조회하도록 변경했습니다.
```jsx
const reserved10mKeys = useMemo(() => {
  const slots = reservedTimeSlotsByRoom?.[roomId] || [];
  return new Set(slots.map(slotKey10m));
}, [reservedTimeSlotsByRoom, roomId]);
```
이를 통해 다수의 타임슬롯이 렌더링되는 상황에서도 불필요한 반복 계산을 줄일 수 있도록 개선했습니다.
 
### 🏞 스크린샷
#### 😢 최적화 적용 전 Lighthouse 결과
<img width="712" height="632" alt="실습2" src="https://github.com/user-attachments/assets/fd642055-75e2-4a90-be25-7ede7635723a" />
<img width="706" height="284" alt="실습3" src="https://github.com/user-attachments/assets/bedfd07d-4a1c-4eea-aa66-22301043c93d" />


#### 😄 최적화 적용 후 Lighthouse 결과
 
<img width="762" height="662" alt="실습6" src="https://github.com/user-attachments/assets/4de2b476-1f9a-4f56-94b6-f0694a6233e7" />
<img width="763" height="279" alt="실습7" src="https://github.com/user-attachments/assets/c8096436-a959-4868-bec5-4f45bb94a606" />


### 🔗 관련 이슈 
- #228 