### PR TITLE
[Refactor] refresh token 기반 access token 재발급으로 인증 복구 플로우 구현

### DIFF
--- a/src/app/admin/login/page.jsx
+++ b/src/app/admin/login/page.jsx
@@ -20,8 +20,11 @@ export default function AdminLogin() {
 
   const router = useRouter();
 
-  const { setAccessToken: setGlobalAccessToken, setRefreshToken } =
-    useTokenStore();
+  const {
+    setAccessToken: setGlobalAccessToken,
+    setRefreshToken,
+    clearTokens,
+  } = useTokenStore();
 
   const handleLoginSave = () => {
     setIsLoginSave(!isLoginSave);
@@ -62,6 +65,7 @@ export default function AdminLogin() {
         if (decoded.role === 'ROLE_ADMIN') {
           router.push('/admin/dashboard');
         } else {
+          clearTokens();
           setConfirmError('관리자 권한이 없습니다.');
         }
       } else {

--- a/src/app/login/page.jsx
+++ b/src/app/login/page.jsx
@@ -42,7 +42,10 @@ function LoginForm() {
   useEffect(() => {
     const redirect = searchParams.get('redirect');
     if (redirect) {
-      setRedirectUrl(decodeURIComponent(redirect));
+      const decoded = decodeURIComponent(redirect);
+      if (decoded.startsWith('/') && !decoded.startsWith('//')) {
+        setRedirectUrl(decoded);
+      }
     }
 
     // 저장된 로그인 정보 불러오기

--- a/src/libs/api/instance.js
+++ b/src/libs/api/instance.js
@@ -5,6 +5,28 @@ const axiosInstance = axios.create({
   timeout: 10000,
 });
 
+// 토큰 갱신 상태 관리
+let isRefreshing = false;
+let failedQueue = [];
+
+const processQueue = (error, token = null) => {
+  failedQueue.forEach(({ resolve, reject }) => {
+    if (error) {
+      reject(error);
+    } else {
+      resolve(token);
+    }
+  });
+  failedQueue = [];
+};
+
+const clearTokens = () => {
+  if (typeof window !== 'undefined') {
+    sessionStorage.removeItem('accessToken');
+    sessionStorage.removeItem('refreshToken');
+  }
+};
+
 axiosInstance.interceptors.request.use(
   (config) => {
     if (typeof window !== 'undefined') {
@@ -13,6 +35,7 @@ axiosInstance.interceptors.request.use(
         '/user/sign-up',
         '/user/code-send',
         '/user/code-verify',
+        '/reissue',
       ];
 
       config.headers = config.headers || {};
@@ -44,13 +67,62 @@ axiosInstance.interceptors.request.use(
 // 응답 인터셉터
 axiosInstance.interceptors.response.use(
   (response) => response,
-  (error) => {
-    const { response } = error;
-    if (response && (response.status === 401 || response.status === 403)) {
-      if (typeof window !== 'undefined') {
-        sessionStorage.removeItem('accessToken');
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (
+      error.response &&
+      error.response.status === 401 &&
+      !originalRequest._retry
+    ) {
+      if (typeof window === 'undefined') {
+        return Promise.reject(error);
+      }
+
+      const refreshToken = sessionStorage.getItem('refreshToken');
+
+      if (!refreshToken) {
+        clearTokens();
+        window.location.href = '/login';
+        return Promise.reject(error);
+      }
+
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        }).then((token) => {
+          originalRequest.headers.Authorization = `Bearer ${token}`;
+          return axiosInstance(originalRequest);
+        });
+      }
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      try {
+        const { data } = await axios.post(
+          `${process.env.NEXT_PUBLIC_API_BASE_URL}/reissue`,
+          null,
+          { headers: { refresh: refreshToken } },
+        );
+
+        const newAccessToken = data.accessToken;
+        sessionStorage.setItem('accessToken', newAccessToken);
+
+        processQueue(null, newAccessToken);
+
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        return axiosInstance(originalRequest);
+      } catch (refreshError) {
+        processQueue(refreshError, null);
+        clearTokens();
+        window.location.href = '/login';
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
       }
     }
+
     return Promise.reject(error);
   },
 );

--- a/src/libs/api/instance.js
+++ b/src/libs/api/instance.js
@@ -24,6 +24,7 @@ const clearTokens = () => {
   if (typeof window !== 'undefined') {
     sessionStorage.removeItem('accessToken');
     sessionStorage.removeItem('refreshToken');
+    sessionStorage.removeItem('userId');
   }
 };
 
@@ -100,14 +101,29 @@ axiosInstance.interceptors.response.use(
       isRefreshing = true;
 
       try {
-        const { data } = await axios.post(
+        const response = await axios.post(
           `${process.env.NEXT_PUBLIC_API_BASE_URL}/reissue`,
           null,
           { headers: { refresh: refreshToken } },
         );
 
-        const newAccessToken = data.accessToken;
-        sessionStorage.setItem('accessToken', newAccessToken);
+        const newAccessToken =
+          response.data?.accessToken ||
+          response.headers['access'] ||
+          response.headers['Access'];
+
+        const newRefreshToken =
+          response.data?.refreshToken ||
+          response.headers['refresh'] ||
+          response.headers['Refresh'];
+
+        if (newAccessToken) {
+          sessionStorage.setItem('accessToken', newAccessToken);
+        }
+
+        if (newRefreshToken) {
+          sessionStorage.setItem('refreshToken', newRefreshToken);
+        }
 
         processQueue(null, newAccessToken);
 

--- a/src/libs/api/instance.js
+++ b/src/libs/api/instance.js
@@ -92,6 +92,9 @@ axiosInstance.interceptors.response.use(
         return new Promise((resolve, reject) => {
           failedQueue.push({ resolve, reject });
         }).then((token) => {
+          if (!token) {
+            return Promise.reject(error);
+          }
           originalRequest.headers.Authorization = `Bearer ${token}`;
           return axiosInstance(originalRequest);
         });
@@ -117,9 +120,11 @@ axiosInstance.interceptors.response.use(
           response.headers['refresh'] ||
           response.headers['Refresh'];
 
-        if (newAccessToken) {
-          sessionStorage.setItem('accessToken', newAccessToken);
+        if (!newAccessToken) {
+          throw new Error('토큰 재발급 응답에 accessToken이 없습니다.');
         }
+
+        sessionStorage.setItem('accessToken', newAccessToken);
 
         if (newRefreshToken) {
           sessionStorage.setItem('refreshToken', newRefreshToken);
@@ -144,7 +149,7 @@ axiosInstance.interceptors.response.use(
 );
 
 export const setAccessToken = (token) => {
-  if (typeof window !== 'undefined') {
+  if (typeof window !== 'undefined' && token) {
     sessionStorage.setItem('accessToken', token);
   }
 };


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- refactor/auth-refresh-token

### 💡 작업개요
`Access Token` 만료(401) 상황에서 사용자가 매번 수동으로 재로그인해야 했던 기존 인증 흐름을 개선하기 위해, `Refresh Token` 기반 자동 재발급 + 원래 요청 자동 복구 구조로 axios 인터셉터를 리팩터링했습니다.

기존에는 401/403 발생 시 `accessToken`만 삭제하고 요청을 실패 처리했기 때문에, 세션이 아직 유효한 상황(`Refresh Token`은 살아있는 상태)에서도 사용자가 “로그인이 풀린 것처럼” 느끼는 문제가 있었습니다.  
특히 페이지 진입이나 탭 전환처럼 요청이 몰리는 구간에서는 **재발급 요청이 중복**되거나, reissue 응답이 불완전할 경우 잘못된 토큰이 후속 요청으로 전파될 수 있는 구조적 위험도 존재했습니다.

“401이면 재발급”을 추가하는 데 그치지 않고, 동시 401 처리, reissue 응답 누락 방어, `Token Rotation` 수용까지 포함해 실제 운영 환경에서도 인증 흐름이 안정적으로 유지되도록 개선하는 데 초점을 맞췄습니다.

또한 이번 작업은 내부 리팩터링 목적과 함께, **“예약이 정상적으로 완료된 것처럼 보였지만 실제로는 반영되지 않았다”는 사용자 건의를 통해 확인된 문제를 해결** 하기 위해 진행했습니다.
로그인 유지 시간이 만료된 상태에서 예약 요청이 이루어질 경우 인증 만료로 인해 예약 API가 실패하면서도 사용자에게는 해당 실패가 명확히 전달되지 않는 흐름이 있었고, 이번 PR을 통해 이러한 인증 만료 상황에서도 요청이 정상적으로 이어질 수 있도록 보완했습니다.

### 🔑 주요 변경사항
#### ✔️ Refresh Token 기반 자동 갱신 + 원래 요청 자동 재시도 (401 처리)
- 401(Access Token 만료)이 발생하면, 먼저 `refreshToken` 존재 여부를 확인합니다.
  - `refreshToken`이 없으면 더 이상 자동 복구가 불가능하므로 토큰을 정리하고 `/login`으로 이동합니다.
  - `refreshToken`이 있으면 `/reissue`로 재발급을 시도하고, 성공 시 새 `accessToken`으로 **실패했던 원래 요청을 자동 재시도**합니다.
- 403은 권한/role 문제 등 “갱신으로 해결되지 않는” 경우가 많아, 이번 PR에서는 refresh 기반 복구 대상에서 제외하고 401에만 집중했습니다. (권한 정책은 추후 별도 PR로 작업 예정입니다.)

>  _☑️ 기존 응답 인터셉터 (Before)_
```js
(error) => {
  const { response } = error;
  if (response && (response.status === 401 || response.status === 403)) {
    if (typeof window !== 'undefined') {
      sessionStorage.removeItem('accessToken');
    }
  }
  return Promise.reject(error);
}
```
- 401 / 403 발생 시 `accessToken`만 제거
- `refreshToken` 활용 없음
- 사용자 재로그인 필수

> _☑️ 변경된 구조 (After)_

**토큰 갱신 상태 관리 변수**
```js
let isRefreshing = false;
let failedQueue = [];
```


**processQueue 유틸 함수**
```js
const processQueue = (error, token = null) => {
  failedQueue.forEach(({ resolve, reject }) => {
    if (error) reject(error);
    else resolve(token);
  });
  failedQueue = [];
};
```
- 갱신 성공 시: 대기 요청들을 새 토큰으로 resolve
- 갱신 실패 시: 대기 요청들을 에러로 reject

**clearTokens 유틸 함수**
```js
const clearTokens = () => {
  if (typeof window !== 'undefined') {
    sessionStorage.removeItem('accessToken');
    sessionStorage.removeItem('refreshToken');
  }
};
```
- 기존 `accessToken` 단독 제거 → `refreshToken`까지 함께 정리

**`/reissue` 엔드포인트 public 처리**
```js
const nonAuthUrls = [
  '/login',
  '/user/sign-up',
  '/user/code-send',
  '/user/code-verify',
  '/reissue',
];
```
- 토큰 재발급 API는 Authorization 헤더 없이 호출

---


#### ✔️ 동시 401(만료) 요청 처리: isRefreshing + failedQueue
- 여러 요청이 동시에 401을 받으면 `/reissue`가 연쇄적으로 호출되면서 토큰 재발급이 중복되는 문제가 존재할 수 있다고 판단했습니다.
- 이를 방지하기 위해
  - 최초 1개 요청만 갱신을 수행하고(`isRefreshing`)
  - 나머지 요청은 `failedQueue`에 대기시킨 뒤
  - 갱신 완료 후 새 토큰을 받아 일괄 재시도하도록 구현했습니다.
  
---

#### ✔️ Token Rotation 적용 (Refresh Token도 함께 갱신)
- `/reissue` 응답에 새 refresh token이 포함되는 경우, 기존 refresh token을 즉시 교체하도록 변경했습니다.
- 서버 구현에 따라 refresh token이 body 또는 header로 내려올 수 있어, `data.refreshToken`과 `headers.refresh/Refresh`를 모두 지원하도록 구현했습니다.

---

#### ✔️ reissue 응답 누락/불완전 방어 (null guard)
- 토큰 재발급 응답에 `accessToken`이 누락되면, 그대로 진행할 경우 `Bearer undefined`로 요청이 나가거나 대기 요청들이 `null token`으로 재시도되는 문제가 생길 수 있습니다.
- 이를 방지하기 위해
  - `accessToken`이 없으면 즉시 throw하여 catch로 흐르게 하고(토큰 정리 + 로그인 이동)
  - 큐에 대기 중인 요청도 `null token`을 받으면 재시도하지 않고 reject하도록 가드했습니다.
  - `setAccessToken(null)` 같은 호출로 `"null"` 문자열이 저장되지 않도록 set 함수에도 필터링을 적용했습니다.

---

#### ✔️ 관리자 로그인 컨텍스트 토큰 잔류 방지
- 일반 유저가 관리자 로그인 페이지에서 로그인을 시도했을 때 토큰이 남아 인증 컨텍스트가 오염될 수 있어, 비관리자 role 감지 시 `clearTokens()`로 즉시 세션을 정리하도록 보강했습니다.

---

#### ✔️ 로그인 redirect 오픈 리다이렉트 방어
- `/login?redirect=...` 파라미터를 decode 후 그대로 신뢰하면 외부 URL로 리다이렉트될 여지가 있어, `/`로 시작하면서 `//`로 시작하지 않는 내부 경로만 허용하도록 제한했습니다.
  
### 🏞 스크린샷

> 건의 내역에 접수된 로그인 리프레쉬 토큰 미구현으로 인한 인증 오류 문제

<img width="294" height="634" alt="image" src="https://github.com/user-attachments/assets/5e0cc7b5-c3e8-401e-a4ad-cd9f77a0b040" />


### 🔗 관련 이슈 
- #217 