### PR TITLE
[Refactor] 건의 내역 조회 공개 범위를 본인만 가능하도록 변경 및 소유권 검증 추가

### DIFF
--- a/src/app/suggest/history/[id]/page.jsx
+++ b/src/app/suggest/history/[id]/page.jsx
@@ -2,13 +2,21 @@
 
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
+import jwtDecode from 'jwt-decode';
 import useTokenStore from '../../../../stores/useTokenStore';
 import axiosInstance from '../../../../libs/api/instance';
 import SuggestionImagesByUrl from '../../../../components/admin/SuggestionImagesByUrl';
 import FooterNav from '@components/common/FooterNav';
 import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
 
-const CATEGORIES = ['분실물', '기물파손', '시설고장', '소음공해', '기타'];
+const CATEGORIES = [
+  '분실물',
+  '기물 파손',
+  '시설 고장',
+  '소음 공해',
+  '미예약 사용자 신고',
+  '기타',
+];
 const PLACES = [
   '스터디룸1',
   '스터디룸2',
@@ -101,6 +109,7 @@ function safeNormalizeSuggestion(raw) {
     category: raw?.category ?? '',
     location: raw?.location ?? '',
     isAnswered: raw?.is_answered ?? raw?.answered ?? raw?.isAnswered ?? false,
+    userId: raw?.userId ?? raw?.user_id ?? raw?.uid ?? null,
     createdAt,
   };
 }
@@ -140,6 +149,16 @@ export default function SuggestHistoryDetailPage({ params }) {
   useEffect(() => {
     if (!accessToken) router.push('/login');
   }, [accessToken, router]);
+
+  const myUserId = useMemo(() => {
+    try {
+      if (!accessToken) return '';
+      const decoded = jwtDecode(accessToken);
+      return decoded.userId || decoded.user_id || decoded.id || '';
+    } catch {
+      return '';
+    }
+  }, [accessToken]);
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -185,6 +204,13 @@ export default function SuggestHistoryDetailPage({ params }) {
       setLoading(true);
       setError('');
       const [d, cmts] = await Promise.all([fetchDetail(), fetchComments()]);
+
+      // 본인 건의가 아니면 접근 차단
+      if (d && myUserId && d.userId && String(d.userId) !== String(myUserId)) {
+        router.replace('/suggest/history');
+        return;
+      }
+
       setDetail(d);
       setComments(cmts);
       setAnswerText(pickLatestAnswerText(cmts));
@@ -193,7 +219,7 @@ export default function SuggestHistoryDetailPage({ params }) {
     } finally {
       setLoading(false);
     }
-  }, [fetchDetail, fetchComments]);
+  }, [fetchDetail, fetchComments, myUserId, router]);
 
   useEffect(() => {
     if (Number.isFinite(suggestId)) reload();

--- a/src/app/suggest/history/[id]/page.jsx
+++ b/src/app/suggest/history/[id]/page.jsx
@@ -2,7 +2,6 @@
 
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
-import jwtDecode from 'jwt-decode';
 import useTokenStore from '../../../../stores/useTokenStore';
 import axiosInstance from '../../../../libs/api/instance';
 import SuggestionImagesByUrl from '../../../../components/admin/SuggestionImagesByUrl';
@@ -142,23 +141,13 @@ function pickLatestAnswerText(list) {
 
 export default function SuggestHistoryDetailPage({ params }) {
   const router = useRouter();
-  const { accessToken } = useTokenStore();
+  const { accessToken, userId: myUserId } = useTokenStore();
   const suggestId = useMemo(() => Number(params?.id), [params?.id]);
 
   // 로그인 체크
   useEffect(() => {
     if (!accessToken) router.push('/login');
   }, [accessToken, router]);
-
-  const myUserId = useMemo(() => {
-    try {
-      if (!accessToken) return '';
-      const decoded = jwtDecode(accessToken);
-      return decoded.userId || decoded.user_id || decoded.id || '';
-    } catch {
-      return '';
-    }
-  }, [accessToken]);
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');

--- a/src/app/suggest/history/[id]/page.jsx
+++ b/src/app/suggest/history/[id]/page.jsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
+import useTokenStore from '../../../../stores/useTokenStore';
 import axiosInstance from '../../../../libs/api/instance';
 import SuggestionImagesByUrl from '../../../../components/admin/SuggestionImagesByUrl';
 import FooterNav from '@components/common/FooterNav';
@@ -132,7 +133,13 @@ function pickLatestAnswerText(list) {
 
 export default function SuggestHistoryDetailPage({ params }) {
   const router = useRouter();
+  const { accessToken } = useTokenStore();
   const suggestId = useMemo(() => Number(params?.id), [params?.id]);
+
+  // 로그인 체크
+  useEffect(() => {
+    if (!accessToken) router.push('/login');
+  }, [accessToken, router]);
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');

--- a/src/app/suggest/history/page.jsx
+++ b/src/app/suggest/history/page.jsx
@@ -3,7 +3,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import jwtDecode from 'jwt-decode';
 import axiosInstance from '../../../libs/api/instance';
 import useTokenStore from '../../../stores/useTokenStore';
 import ThumbByUrl from '../../../components/suggest/ThumbByUrl';
@@ -21,7 +20,7 @@ function BottomSafeSpacer({ height = 64 }) {
 
 export default function SuggestHistoryPage() {
   const router = useRouter();
-  const { accessToken } = useTokenStore();
+  const { accessToken, userId } = useTokenStore();
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -31,16 +30,6 @@ export default function SuggestHistoryPage() {
   useEffect(() => {
     if (!accessToken) router.push('/login');
   }, [accessToken, router]);
-
-  const userId = useMemo(() => {
-    try {
-      if (!accessToken) return '';
-      const decoded = jwtDecode(accessToken);
-      return decoded.userId || decoded.user_id || decoded.id || '';
-    } catch {
-      return '';
-    }
-  }, [accessToken]);
 
   const toArray = (data) => {
     if (Array.isArray(data?.suggestions)) return data.suggestions;

--- a/src/app/suggest/history/page.jsx
+++ b/src/app/suggest/history/page.jsx
@@ -50,12 +50,15 @@ export default function SuggestHistoryPage() {
   };
 
   const fetchMine = useCallback(async () => {
+    if (!userId) {
+      setItems([]);
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     setError('');
     try {
-      const url = userId
-        ? `/api/suggestions?user_id=${encodeURIComponent(userId)}`
-        : '/api/suggestions';
+      const url = `/api/suggestions?user_id=${encodeURIComponent(userId)}`;
       const res = await axiosInstance.get(url);
 
       const raw = toArray(res?.data);


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- refactor/suggestion-visibility-policy

### 💡 작업개요
서비스 내 **건의 내역(History) 조회**를 기존 “전체 공개(모든 사용자의 건의 내역 조회 가능)”에서 **“로그인한 사용자 본인 작성 건의만 조회 가능”** 하도록 리팩터링했습니다. 

> **본 작업은 학교 측에서 건의 내역을 로그인한 사용자 본인만 볼 수 있도록 공개 범위를 수정해달라는 요청을 반영하기 위해 진행된 리팩토링 작업입니다.**

본 작업 초기에 건의 내역 조회 API에 user_id 필터링 작업 후 작업을 진행하면서 확인되는 문제는 크게 3가지였습니다.

1) **목록 페이지에서 userId 미확인 시 전체 목록으로 fallback**
`history/page.jsx`에서 `userId`를 못 구하면 `/api/suggestions`(전체 목록)로 요청이 떨어져 로그인한 사용자라도 타인의 건의가 노출될 수 있는 경로가 존재했습니다.

2) **상세 페이지 직접 URL 접근 가능 + 유저 검증 부재**
`/suggest/history/[id]` 상세 페이지는 비로그인 상태에서도 URL 직접 접근이 가능했고, `suggest_id`만으로 상세 조회가 되어 **타인의 건의 id를 알면 열람/수정/삭제까지 가능한 구조**였습니다.

3) **내가 작성한 건의가 목록에서 조회되지 않는 이슈**
목록 조회 시 `?user_id=...` 서버 필터링을 가정했지만, 실제 API가 해당 파라미터를 지원하지 않거나 또는 userId 추출 로직이 JWT의 실제 클레임(`sub`)과 불일치하여 `userId === ''`가 되어 **API 호출 자체를 건너뛰는 케이스가 발생**했습니다.

✔️ 이번 작업은
- “조회 공개 범위”을 **프론트에서 최소한으로 강제**하고,
- 로그인/유저 검증을 추가하여 **URL로 직접 접근 할 수 있는 방법을 차단**하며,
- 토큰에서 userId를 재추출하지 않고 **useTokenStore의 userId만을 참조하도록**하도록 정리했습니다.

### 🔑 주요 변경사항
#### ✔️ 건의 목록(history)에서 “본인 건의만” 보이도록 조회 공개 범위 강제
기존에는 `userId`가 없을 때 `/api/suggestions`로 fallback 하는 경로가 있어 전체 노출 위험이 있었고, 이후 `?user_id=...` 서버 필터링을 적용했지만 **백엔드단의 응답 형태/필터 미적용**으로 인해 목록이 비어 보이는 문제가 발생했습니다.

따라서 
- `userId`가 없으면 **API 호출 자체를 하지 않고 빈 리스트로 처리** 하고
- 목록 조회는 `/api/suggestions`로 가져온 뒤, 클라이언트에서 **작성자(userId) 기준 필터링**하여 본인 것만 노출하도록 강제했습니다.

```jsx
// src/app/suggest/history/page.jsx

const { accessToken, userId } = useTokenStore();

const fetchMine = useCallback(async () => {
  if (!userId) {
    setItems([]);
    setLoading(false);
    return;
  }

  setLoading(true);
  setError('');

  try {
    const res = await axiosInstance.get('/api/suggestions');
    const raw = toArray(res?.data);

    const list = raw
      .map(normalizeSuggest)
      .filter((item) => {
        const itemUserId = item.userId ?? item.user_id ?? null;
        return itemUserId && String(itemUserId) === String(userId);
      })
      .sort((a, b) => tsDesc(a.createdAt, b.createdAt));

    setItems(list);
  } catch (e) {
    setError('목록 조회 중 오류가 발생했습니다.');
  } finally {
    setLoading(false);
  }
}, [userId]);
```

또한 API 응답 필드가 프로젝트 내에서 `userId`, `user_id`, `uid` 등으로 섞여 들어오는 케이스가 있어, 정규화 함수에 `userId` 추출을 추가했습니다.
```jsx
// src/app/suggest/history/page.jsx
return {
  id: raw?.id ?? raw?.suggest_id ?? raw?.suggestionId,
  userId: raw?.userId ?? raw?.user_id ?? raw?.uid ?? null,
  category: raw?.category ?? '',
  // ...
};
```
#### ✔️ 상세 페이지 직접 접근 방지: 로그인 체크 + 유저 검증 추가
목록은 “본인 것만” 노출되더라도, 상세는 `suggest_id`만으로 조회해서 `/suggest/history/1`, `/suggest/history/2` 처럼 id를 바꿔 넣으면 타인 건의에 접근 가능하던 문제가 있었습니다.

- `accessToken` 없으면 `/login`으로 리다이렉트 하고
- 상세 데이터를 가져온 뒤, `detail.userId`와 `myUserId(useTokenStore)`를 비교해서 불일치하면 `/suggest/history`로 이동시켜 접근을 차단하도록 했습니다.

```jsx
// src/app/suggest/history/[id]/page.jsx

const router = useRouter();
const { accessToken, userId: myUserId } = useTokenStore();

// 로그인 체크
useEffect(() => {
  if (!accessToken) router.push('/login');
}, [accessToken, router]);

const reload = useCallback(async () => {
  setLoading(true);
  setError('');

  try {
    const [d, cmts] = await Promise.all([fetchDetail(), fetchComments()]);

    // 소유자 검증: 본인 건의가 아니면 접근 차단
    if (d && myUserId && d.userId && String(d.userId) !== String(myUserId)) {
      router.replace('/suggest/history');
      return;
    }

    setDetail(d);
    setComments(cmts);
    setAnswerText(pickLatestAnswerText(cmts));
  } finally {
    setLoading(false);
  }
}, [fetchDetail, fetchComments, myUserId, router]);
```

상세 응답 역시 `userId` 필드가 케이스별로 달라 정규화 단계에서 통일했습니다.
```jsx
// src/app/suggest/history/[id]/page.jsx
return {
  // ...
  userId: raw?.userId ?? raw?.user_id ?? raw?.uid ?? null,
  // ...
};
```

#### ✔️ userId 추출 방식 통일: JWT 디코딩 제거 → useTokenStore를 SSOT로 사용
기존에는`history/page.jsx`에서 JWT를 직접 디코딩하며 `userId/user_id/id`만 검사하고 있었는데, 로그인 단계에서 `decoded.sub`를 userId로 쓰는 케이스가 존재했습니다.
결과적으로 `userId === ''`가 되어 `fetchMine`가 호출되지 않거나 빈 목록이 되는 문제가 발생했습니다.

- 페이지에서 JWT를 다시 디코딩하지 않고, 이미 로그인 플로우에서 올바르게 저장된 `useTokenStore.userId`를 그대로 사용하도록 변경했습니다.

#### ✔️ 카테고리 상수(CATEGORIES) 통일
상세 페이지에서 하드코딩된 카테고리 배열이 작성 페이지와 다른 문제가 있었습니다.

- 상세 페이지의 `CATEGORIES`를 작성 페이지 기준으로 통일했습니다.
```jsx
const CATEGORIES = [
  '분실물',
  '기물 파손',
  '시설 고장',
  '소음 공해',
  '미예약 사용자 신고',
  '기타',
];
```
  `
### 🏞 스크린샷
> (BEFORE) 모든 사람의 건의 내역 조회 가능
<img width="295" height="635" alt="image" src="https://github.com/user-attachments/assets/617d4031-25b5-4d57-b58e-86aef78593e3" />



> (AFTER) 로그인된 사용자 본인이 쓴 건의 내역만 조회 가능
<img width="295" height="634" alt="image" src="https://github.com/user-attachments/assets/d9543fb3-b501-42aa-9783-b917c697d84a" />





### 🔗 관련 이슈 
- #