### PR TITLE
[Feat] 전역 404 페이지 구현 및 전체 페이지형 UI 적용

### DIFF
--- a/src/app/not-found.jsx
+++ b/src/app/not-found.jsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <main className="min-h-screen bg-white px-4">
+      <div className="mx-auto flex min-h-screen max-w-[560px] flex-col items-center justify-center py-16">
+        <img
+          src="/maintenance/horse.svg"
+          alt="404 안내 이미지"
+          className="mb-8 h-[160px] w-auto select-none"
+          draggable={false}
+        />
+
+        <h1 className="text-center text-xl font-semibold text-[#788DFF]">
+          페이지를 찾을 수 없어요
+        </h1>
+
+        <p className="mt-3 text-center text-sm leading-6 text-gray-600">
+          요청하신 주소가 변경되었거나 삭제되었을 수 있습니다.
+          <br />
+          주소를 다시 확인해 주세요.
+        </p>
+
+        <div className="mt-8 flex w-full max-w-[360px] gap-3">
+          <button
+            type="button"
+            onClick={() => window.history.back()}
+            className="flex-1 rounded-xl border border-gray-200 px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            이전으로
+          </button>
+
+          <Link
+            href="/"
+            className="flex-1 rounded-xl bg-[#788DFF] px-4 py-3 text-center text-sm font-semibold text-white hover:opacity-90"
+          >
+            홈으로
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/404-not-found-page

### 💡 작업개요
전역 404(Not Found) 페이지를 구현하였습니다.
존재하지 않는 경로 접근 시 사용자에게 안내 UI가 노출되도록 `app/not-found.jsx`를 추가하고, 일반 페이지 형태의 404 화면으로 구성하였습니다.

### 🔑 주요 변경사항
- `src/app/not-found.jsx` 파일 신규 추가하였습니다.

> **파일 경로를 `app/not-found.jsx`로 둔 이유**
Next.js App Router에서는 `not-found.jsx`가 **특수 파일(Special File Convention)** 로 동작합니다.
`app` 루트에 해당 파일을 두면 전역 404 처리가 자동 적용되기에 별도 라우팅 설정 없이 존재하지 않는 모든 경로에 대해 공통 404 UI가 렌더링되도록 하기 위해 경로를 위와 같이 설정하였습니다.

---

- App Router 규칙에 기반해 전역 404 라우팅 적용하였습니다.

---
- `/public/maintenance/horse.svg` 이미지 재사용하였습니다.

> **향후 개선 예정**
`maintenance` 폴더 명칭이 404 용도와 의미적으로 일치하지 않는다고 판단하여 추후 `/public/illustrations` 또는 `/public/assets/illustrations` 등으로 경로를 정리하는 리팩토링 진행 예정입니다.

---

- Client Component로 처리하여 "이전으로" / "홈으로" 버튼을 추가하였습니다.

### 🏞 스크린샷
<img width="318" height="685" alt="image" src="https://github.com/user-attachments/assets/e19b9673-3337-430e-98c8-358012b56cd2" />


### 🔗 관련 이슈 
- #212 