### PR TITLE
[Refactor] 홈(예약) 페이지 ReservationSection 늦은 로딩 개선

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -9,22 +9,13 @@ import Header from '@components/common/Header';
 import Banner from '@components/common/Banner';
 import SecondBanner from '@components/common/SecondBanner';
 import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
+import ReservationSection from '@components/common/ReservationSection';
 
 const AfterLoginBanner = dynamic(
   () => import('@components/common/AfterLoginBanner'),
   {
     ssr: false,
     loading: () => null,
-  },
-);
-
-const ReservationSection = dynamic(
-  () => import('@components/common/ReservationSection'),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="w-full max-w-[95%] min-h-[240px] rounded-2xl bg-white shadow-sm border border-gray-50" />
-    ),
   },
 );
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- refactor/reservation-section-late-loading

### 💡 작업개요
홈 화면 진입 시 **예약하기(ReservationSection)** 이 다른 섹션들보다 눈에 띄게 **늦게 렌더링되는 문제**를 해결했습니다.

기존에는 성능 최적화를 목적으로 `dynamic(() => import(...), { ssr:false })` 형태로 예약 섹션을 **클라이언트 전용 지연 로딩**하도록 구성되어 있었는데, 이 설정이 결과적으로 **초기 진입 UX(초기 콘텐츠 완성도)** 를 저하시켰습니다.

이번 변경에서는 **ReservationSection이 브라우저 전용 API를 사용하지 않는 것이 확인**되어, `ssr:false`가 필수 조건이 아니므로 **일반 import로 원복**하여 **초기 렌더 시점에 바로 표시**되도록 개선했습니다.


### 🔑 주요 변경사항
✔️ `src/app/page.jsx`
- `ReservationSection` import 방식을 **`dynamic(..., { ssr:false })` → 일반 import**로 변경했습니다.
- 불필요해진 dynamic 관련 코드 제거 및 import 위치 정리 진행했습니다.

✔️ `AfterLoginBanner` / `FooterNav` 등 다른 dynamic 컴포넌트는 변경하지 않았습니다.

> ✔️ **왜 “성능 최적화(dynamic)”를 원복했는가?**
> 
> 일반적으로 `dynamic import`는 다음을 기대하고 도입합니다.
> - 초기 번들 크기 감소 (Initial JS payload 감소)
> - 초기 렌더 시 불필요한 컴포넌트의 지연 로딩으로 TTI 개선 가능
> - 브라우저 전용 API(window/document 등) 사용 시 SSR 회피
> 
> 다만 **이번 케이스에서는 `ssr:false`가 “성능 최적화”로 작동하지 않고, “렌더 지연”을 직접 유발**하고 있었습니다.

> **1) `ssr:false`는 “늦게 나오는 게 정상”인 구조라고 생각했습니다**
> `ssr:false`는 서버 렌더 단계에서 ReservationSection을 렌더링하지 않고, 클라이언트에서 **hydration 이후에야** JS 청크를 받아 컴포넌트를 렌더링합니다.
> 
> 즉, 사용자 관점에서는:
> - 첫 화면: ReservationSection 자리에는 placeholder만 보이거나
> - hydration 완료 + 청크 다운로드 완료 후에는 섹션이 뒤늦게 나타날 수 있습니다
> 
> 이 동작은 **네트워크/디바이스/메인스레드 상황에 따라 지연이 더 커질 수 있는 구조**라, “초기 진입 시 예약 섹션이 늦게 뜨는 문제”가 발생합니다.
> 
> **2) 브라우저 전용 API 사용이 없어서 SSR 회피 목적이 성립하지 않습니다**
> ReservationSection 및 하위 컴포넌트들을 확인했을 때 `window`, `document`, `localStorage`, `navigator` 등 **SSR에서 문제되는 브라우저 전용 API 의존성이 없음**을 확인하였습니다.
> 
> 따라서 `ssr:false`로 “SSR을 막아야 할 이유”가 없고, 오히려 SSR 가능 컴포넌트를 SSR에서 제외하는 것이 되어 **초기 콘텐츠 제공만 늦추는 결과가 된다고 판단**했습니다.
> 
> **3) “초기 진입에서 반드시 보여야 하는 섹션”은 지연 로딩이 역효과일 수 있다고 판단했습니다**
> dynamic 분리는 보통 “아래쪽/덜 중요한/상호작용 시점에 필요한” UI에 효과적입니다. 
> 반면 ReservationSection은 홈(예약) 페이지의 핵심 콘텐츠로, 초기 진입 시 사용자에게 **즉시 보여야** 하는 정보 성격이 강합니다.
> 
> 이 경우에는 초기 번들을 조금 줄이더라도, **콘텐츠 완성도가 늦게 채워지는 것 자체가 UX 비용이 더 크다고 판단**했습니다.
> 
> ➡️ 이 케이스에서는 dynamic(`ssr:false`)가 **성능 최적화라기보다 “초기 표시 지연”을 만드는 원인**이어서, SSR 가능한 컴포넌트는 **정적 import로 포함시키는 것이 더 합리적이라 판단**했습니다.

### 🏞 스크린샷

> Before

https://github.com/user-attachments/assets/88db74a6-ca78-4a9b-9a96-8730e501600d


> After

https://github.com/user-attachments/assets/c5c5bd6f-93c0-4b8c-bc25-ae25450fcfe1



### 🔗 관련 이슈 
- #239 