### PR TITLE
[Hotfix] 배포 환경에서 비로그인 예약 시간 UI가 현재 시각과 다르게 표시되는 문제 수정

### DIFF
--- a/src/components/reservation/ReservationComponent.jsx
+++ b/src/components/reservation/ReservationComponent.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import useTokenStore from '../../stores/useTokenStore';
 import useReservationStore from '../../stores/useReservationStore';
@@ -9,38 +9,39 @@ import TimeComponent from '@components/reservation/TimeComponent';
 import Modal from '@components/common/Modal';
 import LoginRequiredModal from '@components/common/LoginRequiredModal';
 
-// KST(Asia/Seoul) 현재시각
-const nowInKST = () =>
-  new Date(new Date().toLocaleString('en-US', { timeZone: 'Asia/Seoul' }));
+// 타임존 안전 유틸 (KST = UTC+9, DST 없음)
+const KST_MS = 9 * 60 * 60 * 1000;
+const TEN_MIN = 10 * 60 * 1000;
 
-// 서버로 보낼 때 KST 로컬 시간을 ISO 형식(초까지)으로 전송
-const toKSTISOString = (date) => {
-  const offset = date.getTimezoneOffset() * 60000;
-  return new Date(date.getTime() - offset).toISOString().slice(0, 19);
+// UTC 타임스탬프에서 KST 시/분 추출
+const kstHour = (utcMs) => new Date(utcMs + KST_MS).getUTCHours();
+const kstMinute = (utcMs) => new Date(utcMs + KST_MS).getUTCMinutes();
+
+// KST HH:MM 포맷
+const formatTime = (utcMs) =>
+  `${String(kstHour(utcMs)).padStart(2, '0')}:${String(kstMinute(utcMs)).padStart(2, '0')}`;
+
+// 오늘 KST 자정의 UTC 타임스탬프
+const todayKSTMidnightUTC = () => {
+  const kst = new Date(Date.now() + KST_MS);
+  return (
+    Date.UTC(kst.getUTCFullYear(), kst.getUTCMonth(), kst.getUTCDate()) - KST_MS
+  );
 };
 
-const formatTime = (date) =>
-  `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
-
-// 10분 슬롯 키 (밀리초 단위, 10분 경계에 맞춰 스냅)
+// 10분 슬롯 키 (UTC 타임스탬프를 10분 경계로 스냅)
 const slotKey10m = (d) => {
-  const t = new Date(d);
-  t.setSeconds(0, 0);
-  const m = t.getMinutes();
-  t.setMinutes(m - (m % 10));
-  return t.getTime();
+  const ms = typeof d === 'number' ? d : new Date(d).getTime();
+  return ms - (ms % TEN_MIN);
 };
 
+// ISO 문자열에 분 추가
 const addMinutesISO = (iso, minutes) =>
   new Date(new Date(iso).getTime() + minutes * 60000).toISOString();
 
-// 오늘(현지 PC 타임존 무관) KST 기준 00:00 Date
-const todayKSTMidnight = () => {
-  const n = nowInKST();
-  const t = new Date(n);
-  t.setHours(0, 0, 0, 0);
-  return t;
-};
+// UTC 타임스탬프를 KST ISO 형식 문자열로 변환 (서버 전송용)
+const toKSTISOString = (utcMs) =>
+  new Date(utcMs + KST_MS).toISOString().slice(0, 19);
 
 const ReservationComponent = ({ index, roomId }) => {
   const [open, setOpen] = useState(false);
@@ -69,53 +70,45 @@ const ReservationComponent = ({ index, roomId }) => {
     return set;
   }, [reservedTimeSlotsByRoom, roomId]);
 
-  // KST 오늘 타임슬롯(10분 단위) + 표시 전용 23:59
+  // KST 오늘 타임슬롯(10분 단위) UTC 타임스탬프 배열 + 표시 전용 23:59
   const timeSlots = useMemo(() => {
+    const midnight = todayKSTMidnightUTC();
     const slots = [];
-    const base = todayKSTMidnight();
-    const end = new Date(base);
-    end.setHours(23, 50, 0, 0);
-    const walker = new Date(base);
-
-    while (walker <= end) {
-      slots.push(new Date(walker));
-      walker.setMinutes(walker.getMinutes() + 10);
+    // 00:00 ~ 23:50 (144개 슬롯)
+    for (let i = 0; i < 144; i++) {
+      slots.push(midnight + i * TEN_MIN);
     }
-    const disp = new Date(base);
-    disp.setHours(23, 59, 0, 0);
-    slots.push(disp);
-
+    // 표시 전용 23:59
+    slots.push(midnight + (23 * 60 + 59) * 60 * 1000);
     return slots;
   }, []);
 
   // 특정 구간이 예약과 충돌하는지 검사 (start 포함, end 제외)
   const isRangeAvailable = (startISO, endISO) => {
-    const start = new Date(startISO);
-    const end = new Date(endISO);
-    const walker = new Date(start);
-    while (walker < end) {
-      if (reserved10mKeys.has(slotKey10m(walker))) return false;
-      walker.setMinutes(walker.getMinutes() + 10);
+    const startMs = new Date(startISO).getTime();
+    const endMs = new Date(endISO).getTime();
+    for (let ms = startMs; ms < endMs; ms += TEN_MIN) {
+      if (reserved10mKeys.has(slotKey10m(ms))) return false;
     }
     return true;
   };
 
   // 슬롯 색상 판정: past > reserved > available
-  const getStatus = (timeISO) => {
-    const t = new Date(timeISO);
+  const getStatus = (slotMs) => {
+    const h = kstHour(slotMs);
+    const m = kstMinute(slotMs);
 
     // 23:59(표시 전용)는 end 계산에서 10분 더하지 않음
-    const isDisplayLast = t.getHours() === 23 && t.getMinutes() === 59;
+    const isDisplayLast = h === 23 && m === 59;
 
-    const slotEnd = isDisplayLast
-      ? new Date(t) // 표시에만 쓰므로 end == start 취급
-      : new Date(t.getTime() + 10 * 60 * 1000);
+    const slotEndMs = isDisplayLast
+      ? slotMs // 표시에만 쓰므로 end == start 취급
+      : slotMs + TEN_MIN;
 
-    const now = nowInKST();
-    const isPast = slotEnd.getTime() <= now.getTime(); // end <= now 이면 과거
+    const isPast = slotEndMs <= Date.now(); // end <= now 이면 과거
 
     if (!isDisplayLast && isPast) return 'past';
-    if (reserved10mKeys.has(slotKey10m(t))) return 'reserved';
+    if (reserved10mKeys.has(slotKey10m(slotMs))) return 'reserved';
     return 'available';
   };
 
@@ -138,10 +131,9 @@ const ReservationComponent = ({ index, roomId }) => {
       return;
     }
 
-    const reservationStart = new Date(startTime);
-    const reservationEnd = new Date(endTime);
-    const duration =
-      durationMinutes ?? (reservationEnd - reservationStart) / (1000 * 60);
+    const startMs = new Date(startTime).getTime();
+    const endMs = new Date(endTime).getTime();
+    const duration = durationMinutes ?? (endMs - startMs) / (1000 * 60);
 
     if (duration !== 60 && duration !== 120) {
       alert('예약은 1시간 또는 2시간 단위로만 가능합니다.');
@@ -152,8 +144,8 @@ const ReservationComponent = ({ index, roomId }) => {
       const res = await axiosInstance.post('/api/reservations', {
         userId,
         roomId,
-        reservationStartTime: toKSTISOString(reservationStart),
-        reservationEndTime: toKSTISOString(reservationEnd),
+        reservationStartTime: toKSTISOString(startMs),
+        reservationEndTime: toKSTISOString(endMs),
       });
 
       alert(res.data.message || '예약이 완료되었습니다.');
@@ -176,67 +168,76 @@ const ReservationComponent = ({ index, roomId }) => {
 
   // KST 현재 시각을 10분 단위로 올림(예: 14:03 → 14:10)
   const kstRoundedUpNow = () => {
-    const n = nowInKST();
-    const r = new Date(n);
-    r.setSeconds(0, 0);
-    const m = r.getMinutes();
-    r.setMinutes(m % 10 === 0 ? m : m + (10 - (m % 10)));
-    return r;
+    const now = Date.now();
+    // 초 이하 제거 (분 단위로 내림)
+    const minuteMs = now - (now % 60000);
+    // 10분 경계로 올림
+    const remainder = minuteMs % TEN_MIN;
+    return remainder === 0 ? minuteMs : minuteMs + (TEN_MIN - remainder);
   };
 
   // 오늘 모달: 시작시간 옵션(미래+비예약만)
   const renderStartTimeOptions = () => {
     const rounded = kstRoundedUpNow();
-    const end = todayKSTMidnight();
-    end.setHours(23, 50, 0, 0);
+    const midnight = todayKSTMidnightUTC();
+    const endMs = midnight + (23 * 60 + 50) * 60 * 1000; // 23:50 KST
 
     const options = [];
-    const walker = new Date(rounded);
-    while (walker <= end) {
-      const k = slotKey10m(walker);
-      if (!reserved10mKeys.has(k)) {
-        options.push(new Date(walker));
+    for (let ms = rounded; ms <= endMs; ms += TEN_MIN) {
+      if (!reserved10mKeys.has(slotKey10m(ms))) {
+        options.push(ms);
       }
-      walker.setMinutes(walker.getMinutes() + 10);
     }
 
-    return options.map((time) => (
-      <option key={time.toISOString()} value={time.toISOString()}>
-        {formatTime(time)}
-      </option>
-    ));
+    return options.map((ms) => {
+      const iso = new Date(ms).toISOString();
+      return (
+        <option key={iso} value={iso}>
+          {formatTime(ms)}
+        </option>
+      );
+    });
   };
 
   // 오늘 모달: 종료시간 후보(1h/2h) 중 충돌 없는 것만
   const renderEndTimeOptions = () => {
     if (!startTime) return [];
-    const start = new Date(startTime);
-    const end1 = new Date(start.getTime() + 60 * 60000);
-    const end2 = new Date(start.getTime() + 120 * 60000);
+    const startMs = new Date(startTime).getTime();
+    const end1Ms = startMs + 60 * 60000;
+    const end2Ms = startMs + 120 * 60000;
+    const startISO = new Date(startMs).toISOString();
 
-    const candidates = [end1, end2].filter((time) =>
-      isRangeAvailable(start.toISOString(), time.toISOString()),
+    const candidates = [end1Ms, end2Ms].filter((ms) =>
+      isRangeAvailable(startISO, new Date(ms).toISOString()),
     );
 
-    return candidates.map((time) => (
-      <option key={time.toISOString()} value={time.toISOString()}>
-        {formatTime(time)}
-      </option>
-    ));
+    return candidates.map((ms) => {
+      const iso = new Date(ms).toISOString();
+      return (
+        <option key={iso} value={iso}>
+          {formatTime(ms)}
+        </option>
+      );
+    });
+  };
+
+  // KST 오늘 날짜 표시용
+  const todayKSTDisplay = () => {
+    const kst = new Date(Date.now() + KST_MS);
+    return `${kst.getUTCMonth() + 1}월 ${kst.getUTCDate()}일`;
   };
 
   const renderLine = (slots) => (
     <div className="w-full overflow-x-auto pb-3">
       <div className="flex flex-row min-w-[720px] sm:min-w-0">
-        {slots.map((time) => {
-          const hour = time.getHours();
-          const isFirstOfHour = time.getMinutes() === 0;
-          const timeISO = time.toISOString();
-          const status = getStatus(timeISO);
+        {slots.map((ms) => {
+          const hour = kstHour(ms);
+          const isFirstOfHour = kstMinute(ms) === 0;
+          const status = getStatus(ms);
 
           return (
             <div
-              key={timeISO}
+              key={ms}
               className="flex flex-col items-center"
               style={{ width: '10px' }}
             >
@@ -261,8 +262,8 @@ const ReservationComponent = ({ index, roomId }) => {
   );
 
   const renderTimeBlocks = () => {
-    const morning = timeSlots.filter((t) => t.getHours() < 12);
-    const afternoon = timeSlots.filter((t) => t.getHours() >= 12);
+    const morning = timeSlots.filter((ms) => kstHour(ms) < 12);
+    const afternoon = timeSlots.filter((ms) => kstHour(ms) >= 12);
     return (
       <div className="flex flex-col gap-2">
         {morning.length > 0 && (
@@ -303,10 +304,7 @@ const ReservationComponent = ({ index, roomId }) => {
           <div className="p-4 flex flex-col h-full">
             <div className="font-semibold text-2xl">스터디룸 {index}</div>
             <div className="flex justify-center items-center text-sm text-gray-500">
-              {nowInKST().toLocaleDateString('ko-KR', {
-                month: 'long',
-                day: 'numeric',
-              })}
+              {todayKSTDisplay()}
             </div>
             <div className="flex flex-col mt-4 mb-4">{renderTimeBlocks()}</div>
 

--- a/src/components/reservation/TomorrowReservationComponent.jsx
+++ b/src/components/reservation/TomorrowReservationComponent.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import useTokenStore from '../../stores/useTokenStore';
 import useReservationStore from '../../stores/useReservationStore';
@@ -9,26 +9,43 @@ import TimeComponent from '@components/reservation/TimeComponent';
 import Modal from '@components/common/Modal';
 import LoginRequiredModal from '@components/common/LoginRequiredModal';
 
-// 서버로 보낼 때 KST 로컬 시간을 ISO 형식(초까지)으로 전송
-const toKSTISOString = (date) => {
-  const offset = date.getTimezoneOffset() * 60000;
-  return new Date(date.getTime() - offset).toISOString().slice(0, 19);
+//타임존 안전 유틸 (KST = UTC+9, DST 없음)
+const KST_MS = 9 * 60 * 60 * 1000;
+const TEN_MIN = 10 * 60 * 1000;
+
+// UTC 타임스탬프에서 KST 시/분 추출
+const kstHour = (utcMs) => new Date(utcMs + KST_MS).getUTCHours();
+const kstMinute = (utcMs) => new Date(utcMs + KST_MS).getUTCMinutes();
+
+// KST HH:MM 포맷
+const formatTime = (utcMs) =>
+  `${String(kstHour(utcMs)).padStart(2, '0')}:${String(kstMinute(utcMs)).padStart(2, '0')}`;
+
+// 오늘 KST 자정의 UTC 타임스탬프
+const todayKSTMidnightUTC = () => {
+  const kst = new Date(Date.now() + KST_MS);
+  return (
+    Date.UTC(kst.getUTCFullYear(), kst.getUTCMonth(), kst.getUTCDate()) - KST_MS
+  );
 };
 
-const formatTime = (date) =>
-  `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+// 내일 KST 자정의 UTC 타임스탬프
+const tomorrowKSTMidnightUTC = () =>
+  todayKSTMidnightUTC() + 24 * 60 * 60 * 1000;
 
-// 10분 슬롯 키 (밀리초 단위, 10분 경계에 맞춰 스냅)
+// 10분 슬롯 키 (UTC 타임스탬프를 10분 경계로 스냅)
 const slotKey10m = (d) => {
-  const t = new Date(d);
-  t.setSeconds(0, 0);
-  const m = t.getMinutes();
-  t.setMinutes(m - (m % 10));
-  return t.getTime();
+  const ms = typeof d === 'number' ? d : new Date(d).getTime();
+  return ms - (ms % TEN_MIN);
 };
 
+// ISO 문자열에 분 추가
 const addMinutesISO = (iso, minutes) =>
   new Date(new Date(iso).getTime() + minutes * 60000).toISOString();
+
+// UTC 타임스탬프를 KST ISO 형식 문자열로 변환 (서버 전송용)
+const toKSTISOString = (utcMs) =>
+  new Date(utcMs + KST_MS).toISOString().slice(0, 19);
 
 const TomorrowReservationComponent = ({ index, roomId }) => {
   const [open, setOpen] = useState(false);
@@ -47,18 +64,14 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
 
   const router = useRouter();
 
-  // 내일 00:00 기준일
-  const tomorrow = useMemo(() => {
-    const date = new Date();
-    date.setDate(date.getDate() + 1);
-    date.setHours(0, 0, 0, 0);
-    return date;
-  }, []);
+  // 내일 KST 자정 UTC 타임스탬프
+  const tomorrowMidnight = useMemo(() => tomorrowKSTMidnightUTC(), []);
 
-  const formattedTomorrow = tomorrow.toLocaleDateString('ko-KR', {
-    month: 'long',
-    day: 'numeric',
-  });
+  // KST 내일 날짜 표시용
+  const formattedTomorrow = useMemo(() => {
+    const kst = new Date(tomorrowMidnight + KST_MS);
+    return `${kst.getUTCMonth() + 1}월 ${kst.getUTCDate()}일`;
+  }, [tomorrowMidnight]);
 
   // 예약된 10분 슬롯 키 집합 (빠른 충돌 판정을 위해)
   const reserved10mKeys = useMemo(() => {
@@ -70,40 +83,31 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
     return set;
   }, [reservedTimeSlotsByRoom, roomId]);
 
-  // 내일의 10분 단위 타임슬롯 + 표시 전용 23:59
+  // 내일의 10분 단위 타임슬롯 UTC 타임스탬프 배열 + 표시 전용 23:59
   const timeSlots = useMemo(() => {
     const slots = [];
-    const base = new Date(tomorrow);
-    const end = new Date(tomorrow);
-    end.setHours(23, 50, 0, 0);
-    while (base <= end) {
-      slots.push(new Date(base));
-      base.setMinutes(base.getMinutes() + 10);
+    // 00:00 ~ 23:50 (144개 슬롯)
+    for (let i = 0; i < 144; i++) {
+      slots.push(tomorrowMidnight + i * TEN_MIN);
     }
     // 표시 전용 23:59
-    const disp = new Date(tomorrow);
-    disp.setHours(23, 59, 0, 0);
-    slots.push(disp);
+    slots.push(tomorrowMidnight + (23 * 60 + 59) * 60 * 1000);
     return slots;
-  }, [tomorrow]);
+  }, [tomorrowMidnight]);
 
   // 특정 구간이 예약과 충돌하는지 검사 (start 포함, end 제외)
   const isRangeAvailable = (startISO, endISO) => {
-    const start = new Date(startISO);
-    const end = new Date(endISO);
-    const walker = new Date(start);
-    while (walker < end) {
-      if (reserved10mKeys.has(slotKey10m(walker))) return false;
-      walker.setMinutes(walker.getMinutes() + 10);
+    const startMs = new Date(startISO).getTime();
+    const endMs = new Date(endISO).getTime();
+    for (let ms = startMs; ms < endMs; ms += TEN_MIN) {
+      if (reserved10mKeys.has(slotKey10m(ms))) return false;
     }
     return true;
   };
 
-  const getStatus = (timeISO) => {
+  const getStatus = (slotMs) => {
     // 내일 화면은 전체가 미래이므로 past는 없음. 예약 여부만 표시.
-    // 표시 전용 23:59는 그냥 available과 동일하게 렌더(필요시 별도 처리)
-    const isReserved = reserved10mKeys.has(slotKey10m(timeISO));
-    if (isReserved) return 'reserved';
+    if (reserved10mKeys.has(slotKey10m(slotMs))) return 'reserved';
     return 'available';
   };
 
@@ -126,10 +130,9 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
       return;
     }
 
-    const reservationStart = new Date(startTime);
-    const reservationEnd = new Date(endTime);
-    const duration =
-      durationMinutes ?? (reservationEnd - reservationStart) / (1000 * 60);
+    const startMs = new Date(startTime).getTime();
+    const endMs = new Date(endTime).getTime();
+    const duration = durationMinutes ?? (endMs - startMs) / (1000 * 60);
 
     if (duration !== 60 && duration !== 120) {
       alert('예약은 1시간 또는 2시간 단위로만 가능합니다.');
@@ -140,8 +143,8 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
       const res = await axiosInstance.post('/api/reservations', {
         userId,
         roomId,
-        reservationStartTime: toKSTISOString(reservationStart),
-        reservationEndTime: toKSTISOString(reservationEnd),
+        reservationStartTime: toKSTISOString(startMs),
+        reservationEndTime: toKSTISOString(endMs),
       });
 
       alert(res.data.message || '예약이 완료되었습니다.');
@@ -165,15 +168,14 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
   const renderLine = (slots) => (
     <div className="w-full overflow-x-auto pb-2">
       <div className="flex flex-row min-w-[720px] sm:min-w-0">
-        {slots.map((time) => {
-          const hour = time.getHours();
-          const isFirstOfHour = time.getMinutes() === 0;
-          const timeISO = time.toISOString();
-          const status = getStatus(timeISO);
+        {slots.map((ms) => {
+          const hour = kstHour(ms);
+          const isFirstOfHour = kstMinute(ms) === 0;
+          const status = getStatus(ms);
 
           return (
             <div
-              key={timeISO}
+              key={ms}
               className="flex flex-col items-center"
               style={{ width: '10px' }}
             >
@@ -198,8 +200,8 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
   );
 
   const renderTimeBlocks = () => {
-    const morning = timeSlots.filter((t) => t.getHours() < 12);
-    const afternoon = timeSlots.filter((t) => t.getHours() >= 12);
+    const morning = timeSlots.filter((ms) => kstHour(ms) < 12);
+    const afternoon = timeSlots.filter((ms) => kstHour(ms) >= 12);
     return (
       <div className="flex flex-col gap-2">
         {morning.length > 0 && (
@@ -220,29 +222,42 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
 
   const renderStartTimeOptions = () => {
     return timeSlots
-      .filter((time) => !reserved10mKeys.has(slotKey10m(time)))
-      .map((time) => (
-        <option key={time.toISOString()} value={time.toISOString()}>
-          {formatTime(time)}
-        </option>
-      ));
+      .filter((ms) => {
+        const h = kstHour(ms);
+        const m = kstMinute(ms);
+        // 23:59 표시 전용 슬롯 제외
+        if (h === 23 && m === 59) return false;
+        return !reserved10mKeys.has(slotKey10m(ms));
+      })
+      .map((ms) => {
+        const iso = new Date(ms).toISOString();
+        return (
+          <option key={iso} value={iso}>
+            {formatTime(ms)}
+          </option>
+        );
+      });
   };
 
   const renderEndTimeOptions = () => {
     if (!startTime) return [];
-    const start = new Date(startTime);
-    const end1 = new Date(start.getTime() + 60 * 60000);
-    const end2 = new Date(start.getTime() + 120 * 60000);
+    const startMs = new Date(startTime).getTime();
+    const end1Ms = startMs + 60 * 60000;
+    const end2Ms = startMs + 120 * 60000;
+    const startISO = new Date(startMs).toISOString();
 
-    const candidates = [end1, end2].filter((time) =>
-      isRangeAvailable(start.toISOString(), time.toISOString()),
+    const candidates = [end1Ms, end2Ms].filter((ms) =>
+      isRangeAvailable(startISO, new Date(ms).toISOString()),
     );
 
-    return candidates.map((time) => (
-      <option key={time.toISOString()} value={time.toISOString()}>
-        {formatTime(time)}
-      </option>
-    ));
+    return candidates.map((ms) => {
+      const iso = new Date(ms).toISOString();
+      return (
+        <option key={iso} value={iso}>
+          {formatTime(ms)}
+        </option>
+      );
+    });
   };
 
   return (


### PR DESCRIPTION
## 📌 Issue Number

> #244 

## 🔍 Changes

비로그인 상태에서 예약(홈) 페이지의 시간 UI가 배포 환경에서 현재 시간과 다르게 표시되던 문제를 수정했습니다.

기존에는 로컬 환경에서는 지나간 시간 / 현재 시간 / 미래 시간 구분이 정상적으로 동작했지만, 배포 환경에서는 로그인 전 화면에서 **항상 오늘 20시까지가 지난 시간(검은색)** 으로 표시되는 문제가 있었습니다.

> 기존에는 확인되지 않았던 오류였지만, 띵스룸 서비스를 이용하는 명지대학교 학우분들께서 해당 문제를 건의해주셨습니다.
> 해당 오류가 서비스를 이용하는 과정에서 불편과 혼란을 유발할 수 있다고 판단하여, 최대한 빠른 시일 내에 수정하는 것을 목표로 대응하게 되었습니다.

처음에는 단순히 시간 비교 로직의 문제처럼 보였지만, 실제로는

- 서버와 클라이언트의 타임존 차이
- Next.js 환경에서의 SSR/하이드레이션 차이
- `Date` 객체를 문자열로 변환했다가 다시 파싱하는 방식의 불안정성

이 복합적으로 겹치면서 발생한 문제였습니다.

이번 작업에서는 기능 자체는 변동이 없도록 하고, **시간 계산 로직 전반을 타임존에 영향받지 않는 UTC timestamp 기반 방식으로 재구성**해서  로컬 / 배포 / 로그인 전 / 로그인 후 어떤 환경에서도 동일한 기준으로 UI가 표시되도록 수정했습니다.

특히 이번 수정에서는

- 오늘/내일 예약 컴포넌트의 시간 계산 유틸을 정리하고
- 슬롯 생성, 현재 시각 판정, 예약 가능 여부 판정, 서버 전송용 시간 변환 로직을 모두 **KST 기준의 UTC 산술 연산 방식**으로 통일했습니다.

그 결과 배포 환경에서도 비로그인 상태에서 시간 UI가 현재 시각 기준으로 올바르게 표시되도록 수정했습니다.


## 📃 Describe

### ✔️ 문제 원인: KST 시간을 문자열로 만든 뒤 다시 `Date`로 파싱하던 방식
기존 코드에서는 현재 KST 시간을 얻기 위해 아래와 같은 방식을 사용하고 있었습니다.

```jsx
const nowInKST = () =>
  new Date(new Date().toLocaleString('en-US', { timeZone: 'Asia/Seoul' }));
```
이 방식은 겉보기에는 KST 기준 시간을 만드는 것처럼 보이지만, 실제로는 중간에 문자열 파싱이 한 번 더 들어갑니다.

즉,

1. 현재 시각을 `Asia/Seoul` 기준 문자열로 변환하고

2. 그 문자열을 다시 `new Date(string)`으로 파싱하는 구조인데

이때 문자열을 다시 `Date`로 파싱하는 순간 **실행 환경의 로컬 타임존 기준으로 해석**될 수 있습니다.

그래서 로컬 환경처럼 브라우저/PC 타임존이 KST인 경우에는 우연히 정상처럼 동작했지만, 배포 환경처럼 서버 타임존이 UTC인 경우에는 같은 문자열이 UTC 기준으로 해석되면서 내부 timestamp가 어긋났고, 그 결과 예약 슬롯의 현재 시각 비교가 잘못되어 **오늘 20시까지가 항상 past 처리되는 문제**가 발생하고 있었습니다.

---

### ✔️ SSR / 하이드레이션 환경 차이까지 겹치면서 로그인 전 화면에서만 더 크게 드러났던 문제
이번 오류가 특히 헷갈렸던 이유는 **로그인 후에는 정상처럼 보이는데, 로그인 전 배포 환경에서만 문제가 드러났다는 점**이었습니다.

이 부분은 Next.js 환경에서
- 로그인 전 초기 화면이 서버 렌더링 결과를 먼저 보여주고
- 이후 클라이언트 하이드레이션이 붙는 구조

와도 연결되어 있었습니다.

기존 시간 계산 로직은 서버(UTC)와 클라이언트(KST)에서 서로 다른 결과를 만들 가능성이 있었기 때문에, 로그인 전 초기 렌더 시점에는 잘못된 시간 기준이 먼저 반영되고, 그 상태가 UI에 그대로 드러나면서 배포 환경에서만 문제가 크게 보이는 구조였습니다.

이번 오류를 해결하면서 단순히 “시간 비교식 하나를 고친다”가 아니라, **SSR/CSR 어느 환경에서 실행되더라도 동일한 시간 계산 결과가 나오도록 기준 자체를 바꾸는 작업으로 진행**했습니다.

---

### ✔️ 시간 계산을 전부 UTC timestamp 기반 산술 연산으로 변경
이번 작업에서는 시간 계산의 기준을 전부 문자열 파싱이 아니라 **UTC timestamp 숫자 값**으로 통일했습니다.

기존에는
- `toLocaleString`
- `getHours`, `getMinutes`
- `setHours`, `setMinutes`
- `getTimezoneOffset`

같이 로컬 실행 환경에 영향을 받을 수 있는 API들을 사용하고 있었는데, 이번에는 

- `Date.now()`
- `Date.UTC()`
- `getUTCHours()`
- `getUTCMinutes()`
- `utcMs + KST_MS`

같이 환경에 따라 값이 달라지지 않는 방식으로 정리했습니다.

핵심 로직은 다음과 같습니다.
- KST는 UTC+9이고 DST가 없으므로, `KST_MS = 9시간`을 상수로 둠
- 어떤 시각이든 먼저 UTC timestamp로 계산
- KST 시/분이 필요하면 `utcMs + KST_MS` 후 `getUTCHours()/getUTCMinutes()` 사용
- 슬롯 생성도 `Date` 객체를 계속 수정하는 대신 숫자 밀리초 값 배열로 생성
- 10분 단위 슬롯 판정도 분 단위 보정이 아니라 `ms - (ms % TEN_MIN)` 방식으로 스냅 처리

이렇게 바꾸면서 서버와 클라이언트의 로컬 타임존 차이에 영향을 받지 않도록 수정했습니다.

---

### ✔️ `ReservationComponent.jsx`의 주요 변경 사항
오늘 예약 컴포넌트에서는 현재 시각과 비교되는 로직이 많아서 이번 수정의 핵심이 여기에 가장 많이 반영되었습니다.

주요 변경 내용은 다음과 같습니다.

**1. KST 시간 유틸 전면 교체**
기존에는 KST 시각을 문자열 기반으로 만들어 사용했다면, 수정 후에는 아래와 같이 UTC timestamp 기반 유틸을 별도로 두고 공통으로 사용하도록 정리했습니다.

```js
const KST_MS = 9 * 60 * 60 * 1000;
const TEN_MIN = 10 * 60 * 1000;

const kstHour = (utcMs) => new Date(utcMs + KST_MS).getUTCHours();
const kstMinute = (utcMs) => new Date(utcMs + KST_MS).getUTCMinutes();
```
이를 통해 시/분 추출 자체가 환경 독립적으로 동작하도록 바꿨습니다.

**2. 오늘 자정 계산 방식을 KST 기준 UTC timestamp로 변경**
기존에는 “오늘 00:00”을 `setHours(0, 0, 0, 0)` 방식으로 만들고 있었는데, 이 역시 실행 환경 타임존에 따라 해석이 달라질 수 있었습니다.

수정 후에는 KST 기준 오늘 자정을 **UTC timestamp로 직접 계산**하도록 변경했습니다.
```js
const todayKSTMidnightUTC = () => {
  const kst = new Date(Date.now() + KST_MS);
  return (
    Date.UTC(kst.getUTCFullYear(), kst.getUTCMonth(), kst.getUTCDate()) - KST_MS
  );
};
```
이렇게 하면 “KST 오늘 00:00”이 어느 환경에서도 동일한 절대 시각으로 고정됩니다.

**3. 타임 슬롯을 `Date 객체 배열`이 아니라 `UTC timestamp 배열`로 생성**
기존에는 `Date` 객체를 순회하면서 `setMinutes()`로 10분씩 증가시키는 방식이었는데, 이 방식은 내부적으로 로컬 타임존의 영향을 받을 수 있습니다.

이번에는 00:00부터 23:50까지를 전부 숫자 timestamp로 생성하도록 변경했습니다.
```js
for (let i = 0; i < 144; i++) {
  slots.push(midnight + i * TEN_MIN);
}
```
또한 표시 전용 마지막 값인 `23:59`도 동일하게 UTC timestamp 기준으로 추가했습니다.

**4. 슬롯 상태 판정 로직을 숫자 기반으로 변경**
기존에는 `Date` 객체끼리 비교하거나, 시/분을 로컬 기준으로 확인하는 흐름이 섞여 있었는데 수정 후에는 슬롯 종료 시각과 Date.now()를 직접 비교하도록 정리했습니다.
```js
const isPast = slotEndMs <= Date.now();
```
여기서 `slotEndMs`, `Date.now()` 모두 절대 `timestamp`이기 때문에 서버/클라이언트의 로컬 타임존 차이와 무관하게 past / reserved / available 판정이 일관되게 동작합니다.

**5. 서버 전송용 시간 문자열 변환 로직 교체**
기존에는 `getTimezoneOffset()`을 사용해 KST 문자열을 만드는 방식이었는데, 이 값은 환경마다 달라질 수 있어 서버/클라이언트 일관성이 깨질 수 있었습니다.

수정 후에는 UTC timestamp에 KST offset을 더한 뒤 `toISOString().slice(0, 19)`로 변환하도록 바꿨습니다.
```js
const toKSTISOString = (utcMs) =>
  new Date(utcMs + KST_MS).toISOString().slice(0, 19);
```
이렇게 하면 예약 생성 요청 시 서버에 전달되는 시간도 KST 기준으로 안정적으로 맞출 수 있습니다.

---

### ✔️ `TomorrowReservationComponent.jsx`도 동일한 기준으로 함께 정리
오늘 예약 컴포넌트만 바꾸면 당장 현재 문제는 줄어들 수 있었지만, 내일 예약 컴포넌트도 동일하게 시간/날짜 계산을 하고 있었기 때문에
구조를 맞추기 위해 함께 정리했습니다.


## 👀 To Reviewer
현재 로컬 환경에서는 다음 부분을 중심으로 동작을 확인했습니다.

- 예약(홈) 페이지 진입 시 **현재 시각 기준으로 지난 시간 / 예약 가능 / 예약됨 색상 구분이 정상적으로 적용되는지**
- **비로그인 상태에서도 시간 UI가 정상적으로 계산되는지**
- 예약 가능한 시간만 **시작 시간 옵션에 노출되는지**
- 선택한 시작/종료 시간이 **10분 단위 슬롯 기준으로 정상적으로 계산되는지**
- 서버로 전송되는 `reservationStartTime`, `reservationEndTime` 값이 **KST 기준으로 올바르게 생성되는지**

다만 이번 오류는 배포 환경에서의 **서버 타임존(UTC) + SSR 초기 렌더링 상황에서만 드러났던 문제**였기 때문에 **최종적인 확인은 실제 배포 환경에서 한 번 더 확인이 필요할 것 같아**, main 브랜치에 merge 후 배포된 상태에서 아래 부분 위주로 한 번만 같이 확인해주시면 감사하겠습니다 🥹

- 배포 환경에서 **로그인 전 예약(홈) 페이지 진입 시** 지난 시간 / 예약됨 / 예약 가능 색상 구분이 **현재 시간 기준으로 정상 동작하는지**
- `ReservationComponent`, `TomorrowReservationComponent`의 **시간 계산 기준이 동일하게 정리되었는지**
- 서버 전송용 예약 시작/종료 시간이 **기존 API 스펙과 충돌 없이 동작하는지**
- `23:59` 표시용 슬롯 처리와 **10분 단위 슬롯 스냅 로직이 의도대로 동작하는지**

긴 PR 읽어주셔서 감사하고, 코드에 주석도 같이 달아두었으니, 로직에 대한 의견 편하게 남겨주세요 🙇🏻‍♀️🙌

## 📸 Screenshot

> pr 올리는 현재 시간(pm 04:10) 기준 배포 환경 오류 화면
<img width="294" height="635" alt="image" src="https://github.com/user-attachments/assets/5fe20d50-cace-4702-a538-139bdd7bc250" />


> 현재까지 수정 진행된 현재 시간(pm 04:10) 기준 로컬 환경 화면
<img width="294" height="635" alt="image" src="https://github.com/user-attachments/assets/a703d908-11ef-4327-9800-c76bf2d86d83" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal time handling architecture for reservation components by standardizing UTC-based time calculations and slot management, ensuring more consistent and maintainable code while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->