### PR TITLE
[Hotfix] lint / prettier 오류로 인한 Vercel build 실패 수정

### DIFF
--- a/src/app/(auth)/sign-up/step1/page.jsx
+++ b/src/app/(auth)/sign-up/step1/page.jsx
@@ -2,13 +2,13 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import CustomizedStepper from './customizedStepper';
 import { strictEmailRegex } from '@constants/regex';
 import useSignupStore from '@stores/useSignupStore';
 import axiosInstance from '@api/instance';
 import Button from '@components/common/Button';
 import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
 import FooterNav from '@components/common/FooterNav';
-import CustomizedStepper from './customizedStepper';
 
 function BottomSafeSpacer({ height = 64 }) {
   return (

--- a/src/app/(auth)/sign-up/step2/page.jsx
+++ b/src/app/(auth)/sign-up/step2/page.jsx
@@ -1,12 +1,12 @@
 'use client';
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import CustomizedStepper from './customizedStepper';
 import { isValidPassword } from '@constants/regex';
 import useSignupStore from '@stores/useSignupStore';
 import Button from '@components/common/Button';
 import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
 import FooterNav from '@components/common/FooterNav';
-import CustomizedStepper from './customizedStepper';
 
 function BottomSafeSpacer({ height = 64 }) {
   return (

--- a/src/app/(auth)/sign-up/step3/page.jsx
+++ b/src/app/(auth)/sign-up/step3/page.jsx
@@ -2,11 +2,11 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import axios from 'axios';
+import CustomizedStepper from './customizedStepper';
 import useSignupStore from '@stores/useSignupStore';
 import Button from '@components/common/Button';
 import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
 import FooterNav from '@components/common/FooterNav';
-import CustomizedStepper from './customizedStepper';
 
 function BottomSafeSpacer({ height = 64 }) {
   return (

--- a/src/app/(auth)/sign-up/step4/page.jsx
+++ b/src/app/(auth)/sign-up/step4/page.jsx
@@ -2,10 +2,10 @@
 import React, { Suspense } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
+import CustomizedStepper from './customizedStepper';
 import Button from '@components/common/Button';
 import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
 import FooterNav from '@components/common/FooterNav';
-import CustomizedStepper from './customizedStepper';
 
 function BottomSafeSpacer({ height = 64 }) {
   return (

--- a/src/app/(info)/service-manual/page.jsx
+++ b/src/app/(info)/service-manual/page.jsx
@@ -428,10 +428,7 @@ function QuickStart() {
       </h2>
       <ol className="list-decimal pl-5 space-y-2 text-[15px] leading-[1.9]">
         <li>
-          <Link
-            href="/sign-up/step1"
-            className="text-[#788cff] underline"
-          >
+          <Link href="/sign-up/step1" className="text-[#788cff] underline">
             학교 이메일로 회원가입
           </Link>{' '}
           (인증번호 확인)

--- a/src/app/admin/community/page.jsx
+++ b/src/app/admin/community/page.jsx
@@ -3,8 +3,8 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { jwtDecode } from 'jwt-decode';
-import axiosInstance from '@api/instance';
 import useTokenStore from '../../../stores/useTokenStore';
+import axiosInstance from '@api/instance';
 
 export default function AdminCommunityPage() {
   const router = useRouter();

--- a/src/app/admin/dashboard/page.jsx
+++ b/src/app/admin/dashboard/page.jsx
@@ -3,9 +3,9 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { jwtDecode } from 'jwt-decode';
-import axiosInstance from '@api/instance';
 import InfoModal from '../../../components/common/InfoModal';
 import useTokenStore from '../../../stores/useTokenStore';
+import axiosInstance from '@api/instance';
 import ReservationCard from '@components/admin/ReservationCard';
 
 export default function AdminDashboard() {

--- a/src/app/admin/reservation-detail/page.jsx
+++ b/src/app/admin/reservation-detail/page.jsx
@@ -3,8 +3,8 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { jwtDecode } from 'jwt-decode';
-import axiosInstance from '@api/instance';
 import useTokenStore from '../../../stores/useTokenStore';
+import axiosInstance from '@api/instance';
 
 export default function ReservationDetailPage() {
   const [reservations, setReservations] = useState([]);

--- a/src/app/admin/reservations-by-date/page.jsx
+++ b/src/app/admin/reservations-by-date/page.jsx
@@ -3,8 +3,8 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { jwtDecode } from 'jwt-decode';
-import axiosInstance from '@api/instance';
 import useTokenStore from '../../../stores/useTokenStore';
+import axiosInstance from '@api/instance';
 import ReservationCard from '@components/admin/ReservationCard';
 
 export default function ReservationListPage() {

--- a/src/app/admin/room-management/page.jsx
+++ b/src/app/admin/room-management/page.jsx
@@ -3,9 +3,9 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { jwtDecode } from 'jwt-decode';
+import useTokenStore from '../../../stores/useTokenStore';
 import axiosInstance from '@api/instance';
 import { updateRoomStatus } from '@api/admin';
-import useTokenStore from '../../../stores/useTokenStore';
 
 const ROOM_IDS = [1, 2, 3, 4, 5];
 const DEFAULT_ROOM_IMAGE_SRC = '/static/icons/studyroom_image.png';

--- a/src/app/admin/suggestions/page.jsx
+++ b/src/app/admin/suggestions/page.jsx
@@ -3,11 +3,11 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { jwtDecode } from 'jwt-decode';
-import axiosInstance from '@api/instance';
 import useTokenStore from '../../../stores/useTokenStore';
 import SuggestionImagesByUrl from '../../../components/admin/SuggestionImagesByUrl';
 import AdminSuggestionComments from '../../../components/admin/AdminSuggestionComments';
 import AdminSuggestionReply from '../../../components/admin/AdminSuggestionReply';
+import axiosInstance from '@api/instance';
 
 export default function AdminSuggestionsPage() {
   const router = useRouter();

--- a/src/app/admin/user-detail/[userId]/page.jsx
+++ b/src/app/admin/user-detail/[userId]/page.jsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useEffect, useState, useCallback, useMemo } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { jwtDecode } from 'jwt-decode';
-import axiosInstance from '@api/instance';
 import useTokenStore from '../../../../stores/useTokenStore';
+import axiosInstance from '@api/instance';
 import ReservationItem from '@components/admin/ReservationItem';
 
 const pad = (n) => String(n).padStart(2, '0');
@@ -22,26 +22,26 @@ function formatDateTimeRange(startArray, endArray) {
   return `${y}.${pad(m)}.${pad(d)} ${pad(h)}:${pad(min)} ~ ${pad(h2)}:${pad(min2)}`;
 }
 
-function normalizeStatus(v) {
-  if (v == null) return 'normal';
-  const s = String(v).toLowerCase();
-  if (['blocked', 'block', 'banned', 'inactive', 'disabled'].includes(s))
-    return 'blocked';
-  if (['normal', 'active', 'enabled'].includes(s)) return 'normal';
-  return 'normal';
-}
+// function normalizeStatus(v) {
+//   if (v == null) return 'normal';
+//   const s = String(v).toLowerCase();
+//   if (['blocked', 'block', 'banned', 'inactive', 'disabled'].includes(s))
+//     return 'blocked';
+//   if (['normal', 'active', 'enabled'].includes(s)) return 'normal';
+//   return 'normal';
+// }
 
-function deriveStatus(u) {
-  if (!u) return 'normal';
-  if (typeof u.isBlocked === 'boolean')
-    return u.isBlocked ? 'blocked' : 'normal';
-  if (typeof u.enabled === 'boolean') return u.enabled ? 'normal' : 'blocked';
-  if (u.accountStatus != null) return normalizeStatus(u.accountStatus);
-  if (u.status != null) return normalizeStatus(u.status);
-  return 'normal';
-}
+// function deriveStatus(u) {
+//   if (!u) return 'normal';
+//   if (typeof u.isBlocked === 'boolean')
+//     return u.isBlocked ? 'blocked' : 'normal';
+//   if (typeof u.enabled === 'boolean') return u.enabled ? 'normal' : 'blocked';
+//   if (u.accountStatus != null) return normalizeStatus(u.accountStatus);
+//   if (u.status != null) return normalizeStatus(u.status);
+//   return 'normal';
+// }
 
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+// const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 export default function UserDetailPage() {
   const { userId } = useParams();
@@ -99,69 +99,69 @@ export default function UserDetailPage() {
     }
   }, [userId, fetchUserDetail, fetchUserReservations]);
 
-  const userStatus = useMemo(() => deriveStatus(user), [user]);
+  // const userStatus = useMemo(() => deriveStatus(user), [user]);
   // const isBlocked = userStatus === 'blocked';
 
-  const updateUserStatus = useCallback(
-    async (nextStatus) => {
-      if (!userId)
-        throw new Error(
-          'userId가 없습니다. 라우트 세그먼트 [userId]를 확인하세요.',
-        );
-      const prevUser = user;
-
-      try {
-        // 즉시 UI 업데이트 (Optimistic update)
-        setUser((p) =>
-          p
-            ? {
-                ...p,
-                status: nextStatus,
-                accountStatus: nextStatus,
-                isBlocked: nextStatus === 'blocked',
-                enabled: nextStatus !== 'blocked',
-              }
-            : p,
-        );
-
-        console.log(`Updating user ${userId} status to:`, nextStatus);
-
-        const response = await axiosInstance.put(
-          `/admin/users/${userId}/status`,
-          null,
-          {
-            params: { status: nextStatus },
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-            },
-          },
-        );
-
-        console.log('User status update success:', response.data);
-
-        // API 성공 후 최신 상태 재조회
-        for (let i = 0; i < 3; i++) {
-          await sleep(250 * (i + 1));
-          const fresh = await fetchUserDetail();
-          if (fresh && deriveStatus(fresh) === nextStatus) break;
-        }
-      } catch (e) {
-        console.error('사용자 상태 변경 실패:', e);
-
-        // 실패 시 이전 상태로 롤백
-        setUser(prevUser);
-        throw e;
-      }
-    },
-    [userId, user, fetchUserDetail, accessToken],
-  );
+  // const updateUserStatus = useCallback(
+  //   async (nextStatus) => {
+  //     if (!userId)
+  //       throw new Error(
+  //         'userId가 없습니다. 라우트 세그먼트 [userId]를 확인하세요.',
+  //       );
+  //     const prevUser = user;
+  //
+  //     try {
+  //       // 즉시 UI 업데이트 (Optimistic update)
+  //       setUser((p) =>
+  //         p
+  //           ? {
+  //               ...p,
+  //               status: nextStatus,
+  //               accountStatus: nextStatus,
+  //               isBlocked: nextStatus === 'blocked',
+  //               enabled: nextStatus !== 'blocked',
+  //             }
+  //           : p,
+  //       );
+  //
+  //       console.log(`Updating user ${userId} status to:`, nextStatus);
+  //
+  //       const response = await axiosInstance.put(
+  //         `/admin/users/${userId}/status`,
+  //         null,
+  //         {
+  //           params: { status: nextStatus },
+  //           headers: {
+  //             Authorization: `Bearer ${accessToken}`,
+  //           },
+  //         },
+  //       );
+  //
+  //       console.log('User status update success:', response.data);
+  //
+  //       // API 성공 후 최신 상태 재조회
+  //       for (let i = 0; i < 3; i++) {
+  //         await sleep(250 * (i + 1));
+  //         const fresh = await fetchUserDetail();
+  //         if (fresh && deriveStatus(fresh) === nextStatus) break;
+  //       }
+  //     } catch (e) {
+  //       console.error('사용자 상태 변경 실패:', e);
+  //
+  //       // 실패 시 이전 상태로 롤백
+  //       setUser(prevUser);
+  //       throw e;
+  //     }
+  //   },
+  //   [userId, user, fetchUserDetail, accessToken],
+  // );
 
   // const handleStatusToggle = useCallback(async () => {
   if (!user) return;
 
-  const currentStatus = userStatus;
-  const newStatus = currentStatus === 'normal' ? 'blocked' : 'normal';
-  const statusText = newStatus === 'blocked' ? '차단' : '정상';
+  // const currentStatus = userStatus;
+  // const newStatus = currentStatus === 'normal' ? 'blocked' : 'normal';
+  // const statusText = newStatus === 'blocked' ? '차단' : '정상';
 
   // if (
   //   !confirm(`${user.username}님을 ${statusText} 상태로 변경하시겠습니까?`)

--- a/src/app/admin/user-management/page.jsx
+++ b/src/app/admin/user-management/page.jsx
@@ -3,8 +3,8 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { jwtDecode } from 'jwt-decode';
-import axiosInstance from '@api/instance';
 import useTokenStore from '../../../stores/useTokenStore';
+import axiosInstance from '@api/instance';
 import UserTableRow from '@components/admin/UserTableRow';
 
 export default function UserManagement() {

--- a/src/app/community/page.jsx
+++ b/src/app/community/page.jsx
@@ -127,7 +127,7 @@ export default function CommunityPage() {
                   className={`relative flex-1 py-3 text-sm md:text-base font-medium transition-colors
                     ${active ? 'text-[#4c6fff]' : 'text-gray-500 hover:text-gray-700'}`}
                   role="tab"
-                  aria-pressed={active}
+                  aria-selected={active}
                 >
                   {category.name}
                   <span

--- a/src/app/my/account-info/page.jsx
+++ b/src/app/my/account-info/page.jsx
@@ -3,13 +3,13 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { jwtDecode } from 'jwt-decode';
 import useTokenStore from '../../../stores/useTokenStore';
+import FooterNav from '../../../components/common/FooterNav';
 import axiosInstance from '@api/instance';
 import MyPageHeader from '@components/my/MyPageHeader';
 import MyPageBlock from '@components/my/MyPageBlock';
 import Modal from '@components/common/Modal';
 import LoginRequiredModal from '@components/common/LoginRequiredModal';
 import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
-import FooterNav from '../../../components/common/FooterNav';
 
 function BottomSafeSpacer({ height = 64 }) {
   return (

--- a/src/app/my/cancel-account-step1/page.jsx
+++ b/src/app/my/cancel-account-step1/page.jsx
@@ -4,13 +4,13 @@ import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { jwtDecode } from 'jwt-decode';
 import useTokenStore from '../../../stores/useTokenStore';
-import axiosInstance from '@api/instance';
 import Button from '../../../components/common/Button';
 import PrivacyPolicyFooter from '../../../components/common/PrivacyPolicyFooter';
+import FooterNav from '../../../components/common/FooterNav';
+import axiosInstance from '@api/instance';
 import MyPageHeader from '@components/my/MyPageHeader';
 import Modal from '@components/common/Modal';
 import LoginRequiredModal from '@components/common/LoginRequiredModal';
-import FooterNav from '../../../components/common/FooterNav';
 
 function BottomSafeSpacer({ height = 64 }) {
   return (

--- a/src/app/my/comments/page.jsx
+++ b/src/app/my/comments/page.jsx
@@ -3,12 +3,12 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import useTokenStore from '../../../stores/useTokenStore';
+import FooterNav from '../../../components/common/FooterNav';
 import axiosInstance from '@api/instance';
 import MyPageHeader from '@components/my/MyPageHeader';
 import LoginRequiredModal from '@components/common/LoginRequiredModal';
 import Modal from '@components/common/Modal';
 import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
-import FooterNav from '../../../components/common/FooterNav';
 
 function BottomSafeSpacer({ height = 64 }) {
   return (

--- a/src/app/my/posts/page.jsx
+++ b/src/app/my/posts/page.jsx
@@ -3,12 +3,12 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import useTokenStore from '../../../stores/useTokenStore';
+import FooterNav from '../../../components/common/FooterNav';
 import axiosInstance from '@api/instance';
 import MyPageHeader from '@components/my/MyPageHeader';
 import LoginRequiredModal from '@components/common/LoginRequiredModal';
 import Modal from '@components/common/Modal';
 import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
-import FooterNav from '../../../components/common/FooterNav';
 
 function BottomSafeSpacer({ height = 64 }) {
   return (

--- a/src/app/my/reservation-list/page.jsx
+++ b/src/app/my/reservation-list/page.jsx
@@ -2,11 +2,11 @@
 
 import React, { useEffect, useState } from 'react';
 import useTokenStore from '../../../stores/useTokenStore';
+import FooterNav from '../../../components/common/FooterNav';
 import MyPageHeader from '@components/my/MyPageHeader';
 import ReservationList from '@components/reservation/ReservationList';
 import LoginRequiredModal from '@components/common/LoginRequiredModal';
 import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
-import FooterNav from '../../../components/common/FooterNav';
 
 function BottomSafeSpacer({ height = 64 }) {
   return (

--- a/src/app/suggest/history/[id]/page.jsx
+++ b/src/app/suggest/history/[id]/page.jsx
@@ -3,8 +3,8 @@
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import useTokenStore from '../../../../stores/useTokenStore';
-import axiosInstance from '@api/instance';
 import SuggestionImagesByUrl from '../../../../components/admin/SuggestionImagesByUrl';
+import axiosInstance from '@api/instance';
 import FooterNav from '@components/common/FooterNav';
 import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
 
@@ -152,7 +152,7 @@ export default function SuggestHistoryDetailPage({ params }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [detail, setDetail] = useState(null);
-  const [comments, setComments] = useState([]);
+  const [, setComments] = useState([]);
   const [answerText, setAnswerText] = useState('');
 
   const [editing, setEditing] = useState(false);

--- a/src/app/suggest/history/page.jsx
+++ b/src/app/suggest/history/page.jsx
@@ -3,9 +3,9 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import axiosInstance from '@api/instance';
 import useTokenStore from '../../../stores/useTokenStore';
 import ThumbByUrl from '../../../components/suggest/ThumbByUrl';
+import axiosInstance from '@api/instance';
 import FooterNav from '@components/common/FooterNav';
 import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
 

--- a/src/components/admin/SuggestionImagesByUrl.jsx
+++ b/src/components/admin/SuggestionImagesByUrl.jsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import axiosInstance from '@api/instance';
 import ProtectedImage from './ProtectedImage';
+import axiosInstance from '@api/instance';
 
 export default function SuggestionImagesByUrl({
   suggestPostId,

--- a/src/components/reservation/ReservationList.jsx
+++ b/src/components/reservation/ReservationList.jsx
@@ -2,12 +2,12 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { jwtDecode } from 'jwt-decode';
+import ReservationHistory from './ReservationHistory';
+import CancellationModal from './CancellationModal';
 import axiosInstance from '@api/instance';
 import useTokenStore from '@stores/useTokenStore';
 import useReservationStore from '@stores/useReservationStore';
 import MyPageDate from '@components/my/MyPageDate';
-import ReservationHistory from './ReservationHistory';
-import CancellationModal from './CancellationModal';
 
 const toDateFromRaw = (raw) => {
   if (!raw) return null;

--- a/src/stores/useReservationStore.js
+++ b/src/stores/useReservationStore.js
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
-import axiosInstance from '@api/instance';
 import useTokenStore from './useTokenStore';
+import axiosInstance from '@api/instance';
 
 const parseToDate = (raw) => {
   if (!raw) return null;


### PR DESCRIPTION
## 📌 Issue Number

> #259 

## 🔍 Changes

이전 PR에서 `auth 페이지 라우트 경로 수정으로 404 오류 해결` 작업을 진행한 뒤 실서비스 환경에 배포하려는 과정에서 Vercel 빌드 단계에서 lint 에러가 발생하며 build가 실패하는 문제가 확인되었습니다.

현재 실서비스 환경에서는 회원가입 및 비밀번호 재설정 페이지 접속이 불가능한 상황이었기 때문에 해당 수정 사항을 **빠르게 배포해야 하는 상황**이었고, build failure 원인을 확인한 뒤 **lint / prettier 오류를 수정하는 Hotfix 작업**을 진행했습니다.

## 📃 Describe

### ✔️ import 순서 정리 (`ESLint import/order` 규칙)

여러 파일에서 상대경로 import와 alias import의 순서가 ESLint 규칙(`import/order`)과 맞지 않아 발생하던 lint 에러를 수정했습니다.

기존 코드에서는

- alias import (`@api`, `@components`, `@stores` 등)
- 상대경로 import (`./`, `../`, `../../`)

순서가 혼재되어 있었고, 이로 인해 lint 에러가 발생하고 있었습니다.

이번 수정에서는

- 상대경로 import
- alias import

순서가 ESLint 규칙에 맞도록 **import 위치만 정리**했습니다.

대상 파일 (20개):

- `src/app/(auth)/sign-up/step1~4/page.jsx`
- `src/app/admin/community/page.jsx`
- `src/app/admin/dashboard/page.jsx`
- `src/app/admin/reservation-detail/page.jsx`
- `src/app/admin/reservations-by-date/page.jsx`
- `src/app/admin/room-management/page.jsx`
- `src/app/admin/suggestions/page.jsx`
- `src/app/admin/user-detail/[userId]/page.jsx`
- `src/app/admin/user-management/page.jsx`
- `src/app/my/account-info/page.jsx`
- `src/app/my/cancel-account-step1/page.jsx`
- `src/app/my/comments/page.jsx`
- `src/app/my/posts/page.jsx`
- `src/app/my/reservation-list/page.jsx`
- `src/app/suggest/history/[id]/page.jsx`
- `src/app/suggest/history/page.jsx`
- `src/components/admin/SuggestionImagesByUrl.jsx`
- `src/components/reservation/ReservationList.jsx`
- `src/stores/useReservationStore.js`

---

### ✔️ 미사용 변수 및 함수 정리 (`ESLint no-unused-vars`)

다음 파일에서 실제로 사용되지 않는 변수 및 함수로 인해 발생하던 lint 에러를 정리했습니다.

**src/app/admin/user-detail/[userId]/page.jsx**

다음 항목들은 기존 코드에서 이미 사용되지 않는 상태(dead code)였기 때문에 정리했습니다.

- `useMemo` import 제거
- `normalizeStatus` 함수 주석 처리
- `deriveStatus` 함수 주석 처리
- `sleep` 함수 주석 처리
- `userStatus` 변수 주석 처리
- `updateUserStatus` 콜백 주석 처리
- `currentStatus`, `newStatus`, `statusText` 변수 주석 처리

해당 코드들은 기존에 `handleStatusToggle` 로직이 주석 처리되면서 함께 사용되지 않게 된 상태였습니다.

---

### ✔️ 접근성 속성 수정

**src/app/community/page.jsx**

- `aria-pressed` → `aria-selected`

`role="tab"` 요소에는 WAI-ARIA 명세상 `aria-selected` 속성이 올바른 접근성 속성이기 때문에 이를 수정했습니다.

---

### ✔️ JSX 포맷팅 정리 (`Prettier`)

**src/app/(info)/service-manual/page.jsx**

`<Link>` 태그의 JSX 속성이 Prettier 포맷 규칙과 맞지 않아 발생하던 build 에러를 수정했습니다.

멀티라인으로 작성되어 있던 JSX 속성을 **Prettier 규칙에 맞게 단일 라인 형태로 정리**했습니다.


## 👀 To Reviewer
이번 PR은 **`auth 페이지 라우트 경로 수정으로 404 오류 해결` 작업을 실서비스 환경에 배포하는 과정에서 발생한 build failure를 해결하기 위한 Hotfix**입니다.

현재 실서비스 환경에서는 회원가입 및 비밀번호 재설정 페이지 접속이 불가능한 상황이기 때문에 해당 수정 사항을 빠르게 배포할 필요가 있었고, build 실패 원인이었던 lint / prettier 오류를 정리하는 작업을 먼저 진행했습니다.

아래 부분 위주로 확인해주시면 감사하겠습니다.

- 기존 기능 동작에 영향이 없는지  
- import 정리 과정에서 누락된 dependency가 없는지  
- eslint 규칙 기준에서 추가로 정리할 부분이 없는지

빠르게 merge 후 **실서비스 환경에 재배포하여 회원가입 / 비밀번호 재설정 기능이 정상적으로 동작하는지 확인하고자 합니다.**



<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 커뮤니티 페이지 탭의 접근성 속성을 개선했습니다.

* **변경사항**
  * 관리자 페이지의 사용자 상태 업데이트 기능이 비활성화되었습니다.
  * 전반적인 코드 구조를 정리하고 중복 항목을 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->