### PR TITLE
[Feat] 예약 공간 목록에 휴게공간 1~4 추가

### DIFF
--- a/src/components/reservation/ReservationComponent.jsx
+++ b/src/components/reservation/ReservationComponent.jsx
@@ -286,11 +286,19 @@ const ReservationComponent = ({ index, roomId, roomName, caption, notice }) => {
     <div className="flex flex-col justify-between p-4 sm:p-7 bg-white rounded-2xl w-full max-w-[100%] mt-[1rem]">
       <div className="flex justify-between items-center">
         <div className="flex gap-3 sm:gap-5 items-center">
-          <div className="text-xl sm:text-2xl">
+          <div className="text-xl sm:text-2xl whitespace-nowrap flex-shrink-0">
             {roomName || `스터디룸 ${index}`}
           </div>
-          {caption && <div className="text-[#9999A3] text-sm">{caption}</div>}
-          {notice && <div className="text-[#3250F5] text-xs">{notice}</div>}
+          {caption && (
+            <div className="text-[#9999A3] text-sm whitespace-nowrap flex-shrink-0">
+              {caption}
+            </div>
+          )}
+          {notice && (
+            <div className="text-[#3250F5] text-xs whitespace-pre-line">
+              {notice}
+            </div>
+          )}
         </div>
         <button
           className="bg-[#3250F5] text-white text-lg rounded-3xl px-4 py-2 w-[100px] hover:bg-[#2a47e3] transition-colors duration-200 font-medium"

--- a/src/components/reservation/ReservationComponent.jsx
+++ b/src/components/reservation/ReservationComponent.jsx
@@ -43,7 +43,7 @@ const addMinutesISO = (iso, minutes) =>
 const toKSTISOString = (utcMs) =>
   new Date(utcMs + KST_MS).toISOString().slice(0, 19);
 
-const ReservationComponent = ({ index, roomId }) => {
+const ReservationComponent = ({ index, roomId, roomName, caption, notice }) => {
   const [open, setOpen] = useState(false);
   const [startTime, setStartTime] = useState('');
   const [endTime, setEndTime] = useState('');
@@ -285,9 +285,12 @@ const ReservationComponent = ({ index, roomId }) => {
   return (
     <div className="flex flex-col justify-between p-4 sm:p-7 bg-white rounded-2xl w-full max-w-[100%] mt-[1rem]">
       <div className="flex justify-between items-center">
-        <div className="flex gap-3 sm:gap-5">
-          <div className="text-xl sm:text-2xl">스터디룸 {index}</div>
-          <div className="text-[#9999A3] text-sm">5인실</div>
+        <div className="flex gap-3 sm:gap-5 items-center">
+          <div className="text-xl sm:text-2xl">
+            {roomName || `스터디룸 ${index}`}
+          </div>
+          {caption && <div className="text-[#9999A3] text-sm">{caption}</div>}
+          {notice && <div className="text-[#3250F5] text-xs">{notice}</div>}
         </div>
         <button
           className="bg-[#3250F5] text-white text-lg rounded-3xl px-4 py-2 w-[100px] hover:bg-[#2a47e3] transition-colors duration-200 font-medium"
@@ -302,7 +305,9 @@ const ReservationComponent = ({ index, roomId }) => {
           text="예약하기"
         >
           <div className="p-4 flex flex-col h-full">
-            <div className="font-semibold text-2xl">스터디룸 {index}</div>
+            <div className="font-semibold text-2xl">
+              {roomName || `스터디룸 ${index}`}
+            </div>
             <div className="flex justify-center items-center text-sm text-gray-500">
               {todayKSTDisplay()}
             </div>

--- a/src/components/reservation/TodayReservationList.jsx
+++ b/src/components/reservation/TodayReservationList.jsx
@@ -13,7 +13,7 @@ const TodayReservationList = () => {
     {
       id: 9,
       name: '휴게공간 4',
-      notice: '장애우 전용 공간이므로 장애우 분들만 예약 가능합니다.',
+      notice: '장애우 전용 공간이므로\n장애우 분들만 예약 가능합니다.',
     },
   ];
 

--- a/src/components/reservation/TodayReservationList.jsx
+++ b/src/components/reservation/TodayReservationList.jsx
@@ -1,25 +1,10 @@
 import ReservationComponent from '@components/reservation/ReservationComponent';
+import { ROOMS } from '@constants/rooms';
 
 const TodayReservationList = () => {
-  const rooms = [
-    { id: 1, name: '스터디룸 1', caption: '5인실' },
-    { id: 2, name: '스터디룸 2', caption: '5인실' },
-    { id: 3, name: '스터디룸 3', caption: '5인실' },
-    { id: 4, name: '스터디룸 4', caption: '5인실' },
-    { id: 5, name: '스터디룸 5', caption: '5인실' },
-    { id: 6, name: '휴게공간 1' },
-    { id: 7, name: '휴게공간 2' },
-    { id: 8, name: '휴게공간 3' },
-    {
-      id: 9,
-      name: '휴게공간 4',
-      notice: '장애우 전용 공간이므로\n장애우 분들만 예약 가능합니다.',
-    },
-  ];
-
   return (
     <div className="w-full">
-      {rooms.map((room, index) => (
+      {ROOMS.map((room, index) => (
         <ReservationComponent
           key={room.id}
           index={index + 1}

--- a/src/components/reservation/TodayReservationList.jsx
+++ b/src/components/reservation/TodayReservationList.jsx
@@ -1,12 +1,33 @@
 import ReservationComponent from '@components/reservation/ReservationComponent';
 
 const TodayReservationList = () => {
-  const rooms = [1, 2, 3, 4, 5];
+  const rooms = [
+    { id: 1, name: '스터디룸 1', caption: '5인실' },
+    { id: 2, name: '스터디룸 2', caption: '5인실' },
+    { id: 3, name: '스터디룸 3', caption: '5인실' },
+    { id: 4, name: '스터디룸 4', caption: '5인실' },
+    { id: 5, name: '스터디룸 5', caption: '5인실' },
+    { id: 6, name: '휴게공간 1' },
+    { id: 7, name: '휴게공간 2' },
+    { id: 8, name: '휴게공간 3' },
+    {
+      id: 9,
+      name: '휴게공간 4',
+      notice: '장애우 전용 공간이므로 장애우 분들만 예약 가능합니다.',
+    },
+  ];
 
   return (
     <div className="w-full">
-      {rooms.map((roomId, index) => (
-        <ReservationComponent key={roomId} index={index + 1} roomId={roomId} />
+      {rooms.map((room, index) => (
+        <ReservationComponent
+          key={room.id}
+          index={index + 1}
+          roomId={room.id}
+          roomName={room.name}
+          caption={room.caption}
+          notice={room.notice}
+        />
       ))}
     </div>
   );

--- a/src/components/reservation/TomorrowReservationComponent.jsx
+++ b/src/components/reservation/TomorrowReservationComponent.jsx
@@ -270,11 +270,19 @@ const TomorrowReservationComponent = ({
     <div className="flex flex-col justify-between p-4 sm:p-7 bg-white rounded-2xl w-full max-w-[100%] mt-[1rem]">
       <div className="flex justify-between items-center">
         <div className="flex gap-3 sm:gap-5 items-center">
-          <div className="text-xl sm:text-2xl">
+          <div className="text-xl sm:text-2xl whitespace-nowrap flex-shrink-0">
             {roomName || `스터디룸 ${index}`}
           </div>
-          {caption && <div className="text-[#9999A3] text-sm">{caption}</div>}
-          {notice && <div className="text-[#3250F5] text-xs">{notice}</div>}
+          {caption && (
+            <div className="text-[#9999A3] text-sm whitespace-nowrap flex-shrink-0">
+              {caption}
+            </div>
+          )}
+          {notice && (
+            <div className="text-[#3250F5] text-xs whitespace-pre-line">
+              {notice}
+            </div>
+          )}
         </div>
         <button
           className="bg-[#3250F5] text-white text-lg rounded-3xl px-4 py-2 w-[100px] hover:bg-[#2a47e3] transition-colors duration-200 font-medium"

--- a/src/components/reservation/TomorrowReservationComponent.jsx
+++ b/src/components/reservation/TomorrowReservationComponent.jsx
@@ -47,7 +47,13 @@ const addMinutesISO = (iso, minutes) =>
 const toKSTISOString = (utcMs) =>
   new Date(utcMs + KST_MS).toISOString().slice(0, 19);
 
-const TomorrowReservationComponent = ({ index, roomId }) => {
+const TomorrowReservationComponent = ({
+  index,
+  roomId,
+  roomName,
+  caption,
+  notice,
+}) => {
   const [open, setOpen] = useState(false);
   const [startTime, setStartTime] = useState('');
   const [endTime, setEndTime] = useState('');
@@ -263,9 +269,12 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
   return (
     <div className="flex flex-col justify-between p-4 sm:p-7 bg-white rounded-2xl w-full max-w-[100%] mt-[1rem]">
       <div className="flex justify-between items-center">
-        <div className="flex gap-3 sm:gap-5">
-          <div className="text-xl sm:text-2xl">스터디룸 {index}</div>
-          <div className="text-[#9999A3] text-sm">5인실</div>
+        <div className="flex gap-3 sm:gap-5 items-center">
+          <div className="text-xl sm:text-2xl">
+            {roomName || `스터디룸 ${index}`}
+          </div>
+          {caption && <div className="text-[#9999A3] text-sm">{caption}</div>}
+          {notice && <div className="text-[#3250F5] text-xs">{notice}</div>}
         </div>
         <button
           className="bg-[#3250F5] text-white text-lg rounded-3xl px-4 py-2 w-[100px] hover:bg-[#2a47e3] transition-colors duration-200 font-medium"
@@ -280,7 +289,9 @@ const TomorrowReservationComponent = ({ index, roomId }) => {
           text="예약하기"
         >
           <div className="p-4 flex flex-col h-full">
-            <div className="font-semibold text-2xl">스터디룸 {index}</div>
+            <div className="font-semibold text-2xl">
+              {roomName || `스터디룸 ${index}`}
+            </div>
             <div className="flex justify-center items-center text-sm text-gray-500">
               {formattedTomorrow}
             </div>

--- a/src/components/reservation/TomorrowReservationList.jsx
+++ b/src/components/reservation/TomorrowReservationList.jsx
@@ -1,25 +1,10 @@
 import TomorrowReservationComponent from '@components/reservation/TomorrowReservationComponent';
+import { ROOMS } from '@constants/rooms';
 
 const TomorrowReservationList = () => {
-  const rooms = [
-    { id: 1, name: '스터디룸 1', caption: '5인실' },
-    { id: 2, name: '스터디룸 2', caption: '5인실' },
-    { id: 3, name: '스터디룸 3', caption: '5인실' },
-    { id: 4, name: '스터디룸 4', caption: '5인실' },
-    { id: 5, name: '스터디룸 5', caption: '5인실' },
-    { id: 6, name: '휴게공간 1' },
-    { id: 7, name: '휴게공간 2' },
-    { id: 8, name: '휴게공간 3' },
-    {
-      id: 9,
-      name: '휴게공간 4',
-      notice: '장애우 전용 공간이므로\n장애우 분들만 예약 가능합니다.',
-    },
-  ];
-
   return (
     <div className="w-full">
-      {rooms.map((room, index) => (
+      {ROOMS.map((room, index) => (
         <TomorrowReservationComponent
           key={room.id}
           index={index + 1}

--- a/src/components/reservation/TomorrowReservationList.jsx
+++ b/src/components/reservation/TomorrowReservationList.jsx
@@ -1,15 +1,32 @@
 import TomorrowReservationComponent from '@components/reservation/TomorrowReservationComponent';
 
 const TomorrowReservationList = () => {
-  const rooms = [1, 2, 3, 4, 5];
+  const rooms = [
+    { id: 1, name: '스터디룸 1', caption: '5인실' },
+    { id: 2, name: '스터디룸 2', caption: '5인실' },
+    { id: 3, name: '스터디룸 3', caption: '5인실' },
+    { id: 4, name: '스터디룸 4', caption: '5인실' },
+    { id: 5, name: '스터디룸 5', caption: '5인실' },
+    { id: 6, name: '휴게공간 1' },
+    { id: 7, name: '휴게공간 2' },
+    { id: 8, name: '휴게공간 3' },
+    {
+      id: 9,
+      name: '휴게공간 4',
+      notice: '장애우 전용 공간이므로 장애우 분들만 예약 가능합니다.',
+    },
+  ];
 
   return (
     <div className="w-full">
-      {rooms.map((roomId, index) => (
+      {rooms.map((room, index) => (
         <TomorrowReservationComponent
-          key={roomId}
+          key={room.id}
           index={index + 1}
-          roomId={roomId}
+          roomId={room.id}
+          roomName={room.name}
+          caption={room.caption}
+          notice={room.notice}
         />
       ))}
     </div>

--- a/src/components/reservation/TomorrowReservationList.jsx
+++ b/src/components/reservation/TomorrowReservationList.jsx
@@ -13,7 +13,7 @@ const TomorrowReservationList = () => {
     {
       id: 9,
       name: '휴게공간 4',
-      notice: '장애우 전용 공간이므로 장애우 분들만 예약 가능합니다.',
+      notice: '장애우 전용 공간이므로\n장애우 분들만 예약 가능합니다.',
     },
   ];
 

--- a/src/constants/rooms.js
+++ b/src/constants/rooms.js
@@ -1,0 +1,15 @@
+export const ROOMS = [
+  { id: 1, name: '스터디룸 1', caption: '5인실' },
+  { id: 2, name: '스터디룸 2', caption: '5인실' },
+  { id: 3, name: '스터디룸 3', caption: '5인실' },
+  { id: 4, name: '스터디룸 4', caption: '5인실' },
+  { id: 5, name: '스터디룸 5', caption: '5인실' },
+  { id: 6, name: '휴게공간 1' },
+  { id: 7, name: '휴게공간 2' },
+  { id: 8, name: '휴게공간 3' },
+  {
+    id: 9,
+    name: '휴게공간 4',
+    notice: '장애우 전용 공간이므로\n장애우 분들만 예약 가능합니다.',
+  },
+];


### PR DESCRIPTION
## 📌 Issue Number

> - #255 

## 🔍 Changes

학교 측 요청으로 기존 스터디룸 예약 시스템(띵스룸)에 **휴게공간 1번 ~ 4번 공간에 대한 예약 기능을 추가**했습니다.

최근 학생회관 4층 창의융합라운지 리모델링 이후 새롭게 조성된 **휴게공간 1번 ~ 4번 공간에 대해서도 기존 스터디룸과 동일하게 띵스룸 서비스를 적용해달라는 요청**을 학교 측으로부터 전달받았고, 해당 공간에서도 학생들이 기존 스터디룸과 동일한 방식으로 예약을 통해 이용할 수 있도록 하기 위해 이번 작업을 진행하게 되었습니다.

기존 스터디룸 예약 기능 자체에는 변경이나 수정사항 없이, **기존 예약 로직을 그대로 유지하면서 예약 가능한 공간 목록만 확장하는 방식으로 구현**했습니다.

기존에는 스터디룸 1-5까지만 예약 대상 공간으로 표시되었지만, 이번 작업을 통해 **휴게공간 1-4가 추가되어 총 9개의 예약 공간이 노출**되도록 수정했습니다.

또한 기존 코드에서는 방 이름이나 설명이 일부 하드코딩되어 있어 공간 확장 시 유지보수가 어려운 구조였기 때문에, 예약 컴포넌트에서 **roomName / caption / notice props를 도입하여 방 이름 및 안내 문구를 동적으로 표시할 수 있도록 개선**했습니다.

특히 **휴게공간 4번은 장애우 전용 공간**으로 운영되는 공간이기 때문에,

> "장애우 전용 공간이므로 장애우 분들만 예약 가능합니다."

라는 안내 문구가 함께 표시되도록 UI를 추가했습니다.

이번 작업의 주요 변경 사항은 다음과 같습니다.

- 기존 스터디룸 5개(id 1-5) 외에 **휴게공간 4개(id 6-9)** 예약 공간 추가
- 예약 컴포넌트에서 방 이름 / 설명 / 안내 문구를 props 기반으로 동적 표시하도록 개선
- 휴게공간 4번에 장애인 전용 안내 문구 표시
- 오늘 예약 / 내일 예약 화면 모두 동일하게 공간 목록 확장


## 📃 Describe

### ✔️ `ReservationComponent.jsx`

예약 컴포넌트에서 방 이름과 설명이 일부 하드코딩되어 있어 공간 확장이 어려운 구조였기 때문에  `roomName`, `caption`, `notice` props를 추가해 동적으로 표시할 수 있도록 수정했습니다.

주요 변경 사항은 다음과 같습니다.

- `roomName`, `caption`, `notice` props 추가
- 기존 `스터디룸 {index}` 하드코딩 → `roomName || 스터디룸 ${index}` 방식으로 fallback 유지
- 기존 `5인실` 표시 → `caption` prop 기반 조건부 렌더링으로 변경
- `notice` prop이 존재할 경우 파란색(`#3250F5`) 안내 문구 표시
- BottomSheet 모달 내부 제목도 동일하게 동적 방 이름 사용
- 헤더 영역 정렬을 위해 `items-center` 스타일 추가

---

### ✔️ `TomorrowReservationComponent.jsx`

내일 예약 컴포넌트 역시 동일한 구조로 동작하고 있기 때문에 `ReservationComponent.jsx`와 동일한 방식으로 props 기반 구조를 적용했습니다.

---

### ✔️ `TodayReservationList.jsx`

기존에는 방 목록이 단순 숫자 배열 `[1,2,3,4,5]` 형태로 관리되고 있었는데 휴게공간 추가 및 방 정보 확장을 위해 **객체 배열 구조로 변경**했습니다.

구조는 다음과 같습니다.

- 스터디룸 1~5  
  `{ id, name, caption: '5인실' }`

- 휴게공간 1~3  
  `{ id, name }`

- 휴게공간 4  
  `{ id, name, notice: '장애우 전용 공간이므로 장애우 분들만 예약 가능합니다.' }`

이 정보를 기반으로 `ReservationComponent`에

- `roomName`
- `caption`
- `notice`

props를 전달하도록 수정했습니다.

---

### ✔️ `TomorrowReservationList.jsx`

내일 예약 화면에서도 동일한 공간 목록이 표시되어야 하기 때문에 `TodayReservationList.jsx`와 동일한 구조 변경을 적용했습니다.


## 👀 To Reviewer

현재 로컬 환경에서는 다음 부분을 중심으로 동작을 확인했습니다.

- 오늘 예약 탭에서 **스터디룸 1-5 + 휴게공간 1-4 총 9개 공간이 정상적으로 표시되는지**
- 내일 예약 탭에서도 동일하게 **9개 공간이 표시되는지**
- 스터디룸 항목에 **"5인실" caption이 정상적으로 표시되는지**
- 휴게공간 1~3에는 caption이 표시되지 않는지
- **휴게공간 4에 장애우 전용 안내 문구가 표시되는지**
- 예약 버튼 클릭 시 BottomSheet 모달에 **올바른 방 이름이 표시되는지**
- 예약 생성 / 취소 기능이 **기존 스터디룸과 동일하게 동작하는지**

기존 예약 로직 자체는 변경하지 않고 **공간 목록만 확장하는 방식으로 작업**했기 때문에 기존 스터디룸 예약 기능에는 영향이 없도록 구현했습니다.

다만 실제 운영 환경에서도 정상적으로 표시되는지 확인을 위해 merge 후 배포 환경에서 아래 부분만 한 번 확인해주시면 감사하겠습니다.

리뷰 편하게 남겨주시면 감사하겠습니다 🙇🏻‍♀️


## 📸 Screenshot


https://github.com/user-attachments/assets/179b5919-4403-45d6-90ba-b4acbea66eb5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- 스터디룸 이름 커스터마이징: 기본 번호 대신 제공된 이름 표시
- 방별 설명(caption) 및 공지(notice) 추가: 목록과 예약 모달에 조건부 노출
- 예약 목록 데이터 소스 개선: 방 정보(이름·설명·공지)를 기반으로 표시되어 모달 및 목록의 표시 일관성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->