### PR TITLE
[Chore] Pr/Issue 작성 시 Label, Assignee, Reviewer 자동화

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,106 @@
+enable:
+  issues: true
+  prs: true
+
+labels:
+  "Fix":
+    include:
+      - '\bFix\b'
+      - '\bfix\b'
+      - '\bFIX\b'
+      - '\bBug\b'
+      - '\bbug\b'
+      - '\bBUG\b'
+
+  "Feature":
+    include:
+      - '\bFeat\b'
+      - '\bfeat\b'
+      - '\bFEAT\b'
+      - '\bFeature\b'
+      - '\bfeature\b'
+      - '\bFEATURE\b'
+
+  "Docs":
+    include:
+      - '\bDocs\b'
+      - '\bdocs\b'
+      - '\bDOCS\b'
+
+  "Design":
+    include:
+      - '\bStyle\b'
+      - '\bstyle\b'
+      - '\bSTYLE\b'
+      - '\bDesign\b'
+      - '\bdesign\b'
+      - '\bDESIGN\b'
+      - '\bUI\b'
+      - '\bui\b'
+      - '\bUX\b'
+      - '\bux\b'
+
+  "Chore":
+    include:
+      - '\bChore\b'
+      - '\bchore\b'
+      - '\bCHORE\b'
+
+  "Refactor":
+    include:
+      - '\bRefactor\b'
+      - '\brefactor\b'
+      - '\bREFACTOR\b'
+
+  "Deploy":
+    include:
+      - '\bDeploy\b'
+      - '\bdeploy\b'
+      - '\bDEPLOY\b'
+
+  "Hotfix":
+    include:
+      - '\bHotfix\b'
+      - '\bhotfix\b'
+      - '\bHOTFIX\b'
+
+  "Infra":
+    include:
+      - '\bInfra\b'
+      - '\binfra\b'
+      - '\bINFRA\b'
+      - '\bCI\b'
+      - '\bci\b'
+      - '\bCD\b'
+      - '\bcd\b'
+      - '\bWorkflow\b'
+      - '\bworkflow\b'
+      - '\bWORKFLOW\b'
+      - '\bDocker\b'
+      - '\bdocker\b'
+
+  "Config":
+    include:
+      - '\bConfig\b'
+      - '\bconfig\b'
+      - '\bCONFIG\b'
+      - '\bInit\b'
+      - '\binit\b'
+      - '\bINIT\b'
+      - '\bSetting\b'
+      - '\bsetting\b'
+      - '\bSETTING\b'
+      - '\bSettings\b'
+      - '\bsettings\b'
+      - '\bSETTINGS\b'
+
+  "Pre-release":
+    include:
+      - '\bPre-release\b'
+      - '\bpre-release\b'
+      - '\bPRE-RELEASE\b'
+      - '\bPrerelease\b'
+      - '\bprerelease\b'
+      - '\bPRERELEASE\b'
+      - '\bDemo\b'
+      - '\bdemo\b'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,7 +3,7 @@ enable:
   prs: true
 
 labels:
-  "Fix":
+  "🛠️ Fix":
     include:
       - '\bFix\b'
       - '\bfix\b'
@@ -12,7 +12,7 @@ labels:
       - '\bbug\b'
       - '\bBUG\b'
 
-  "Feature":
+  "✨ Feature":
     include:
       - '\bFeat\b'
       - '\bfeat\b'
@@ -21,13 +21,13 @@ labels:
       - '\bfeature\b'
       - '\bFEATURE\b'
 
-  "Docs":
+  "📄 Docs":
     include:
       - '\bDocs\b'
       - '\bdocs\b'
       - '\bDOCS\b'
 
-  "Design":
+  "🎨 Design":
     include:
       - '\bStyle\b'
       - '\bstyle\b'
@@ -40,31 +40,31 @@ labels:
       - '\bUX\b'
       - '\bux\b'
 
-  "Chore":
+  "🧹 Chore":
     include:
       - '\bChore\b'
       - '\bchore\b'
       - '\bCHORE\b'
 
-  "Refactor":
+  "🔨 Refactor":
     include:
       - '\bRefactor\b'
       - '\brefactor\b'
       - '\bREFACTOR\b'
 
-  "Deploy":
+  "🚀 Deploy":
     include:
       - '\bDeploy\b'
       - '\bdeploy\b'
       - '\bDEPLOY\b'
 
-  "Hotfix":
+  "🔥 Hotfix":
     include:
       - '\bHotfix\b'
       - '\bhotfix\b'
       - '\bHOTFIX\b'
 
-  "Infra":
+  "🔩 Infra":
     include:
       - '\bInfra\b'
       - '\binfra\b'
@@ -79,7 +79,7 @@ labels:
       - '\bDocker\b'
       - '\bdocker\b'
 
-  "Config":
+  "⚙️ Config":
     include:
       - '\bConfig\b'
       - '\bconfig\b'
@@ -94,7 +94,7 @@ labels:
       - '\bsettings\b'
       - '\bSETTINGS\b'
 
-  "Pre-release":
+  "🧪 Pre-release":
     include:
       - '\bPre-release\b'
       - '\bpre-release\b'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,100 @@
+name: Labeler
+
+on:
+  issues:
+    types: [opened, reopened, edited]
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Check Labels
+        id: labeler
+        uses: jimschubert/labeler-action@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add labels based on user
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const isPR = !!context.payload.pull_request;
+            const issueNumber = isPR
+              ? context.payload.pull_request.number
+              : context.payload.issue.number;
+
+            const author = isPR
+              ? context.payload.pull_request.user.login
+              : context.payload.issue.user.login;
+
+            const userLabels = {
+              "u-zzn": "유진 ୨ৎ",
+              "jogpfls": "혜린 ୨ৎ",
+            };
+
+            const labelToAdd = userLabels[author];
+
+            if (labelToAdd) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: [labelToAdd],
+              });
+            }
+
+      - name: Auto assign for issue
+        if: ${{ github.event_name == 'issues' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+            const author = issue.user.login;
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              assignees: [author],
+            });
+
+      - name: Auto assign and request reviewers for PR
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              assignees: [author],
+            });
+
+            const reviewerMap = {
+              "u-zzn": ["jogpfls"],
+              "jogpfls": ["u-zzn"],
+            };
+
+            const reviewers = reviewerMap[author];
+
+            if (reviewers && reviewers.length > 0) {
+              await github.rest.pulls.requestReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                reviewers: reviewers,
+              });
+            }

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -84,15 +84,10 @@ jobs:
               assignees: [author],
             });
 
-            const reviewerMap = {
-              "u-zzn": ["Sohyunnnn", "odukong"],
-              "Sohyunnnn": ["u-zzn", "odukong"],
-              "odukong": ["u-zzn", "Sohyunnnn"],
-            };
+            const allMembers = ["u-zzn", "Sohyunnnn", "odukong"];
+            const reviewers = allMembers.filter((member) => member !== author);
 
-            const reviewers = reviewerMap[author];
-
-            if (reviewers && reviewers.length > 0) {
+            if (reviewers.length > 0) {
               await github.rest.pulls.requestReviewers({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check Labels
         id: labeler
         uses: jimschubert/labeler-action@v2
-        with:
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add labels based on user

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [opened, reopened, edited]
   pull_request:
-    types: [opened, reopened, synchronize, edited]
+    types: [opened, reopened]
 
 jobs:
   labeler:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -3,7 +3,7 @@ name: Labeler
 on:
   issues:
     types: [opened, reopened, edited]
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize, edited]
 
 jobs:
@@ -69,7 +69,7 @@ jobs:
             });
 
       - name: Auto assign and request reviewers for PR
-        if: ${{ github.event_name == 'pull_request_target' }}
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -37,7 +37,8 @@ jobs:
 
             const userLabels = {
               "u-zzn": "유진 ୨ৎ",
-              "jogpfls": "혜린 ୨ৎ",
+              "Sohyunnnn": "소현 ୨ৎ",
+              "odukong": "수빈 ୨ৎ",
             };
 
             const labelToAdd = userLabels[author];
@@ -84,8 +85,9 @@ jobs:
             });
 
             const reviewerMap = {
-              "u-zzn": ["jogpfls"],
-              "jogpfls": ["u-zzn"],
+              "u-zzn": ["Sohyunnnn", "odukong"],
+              "Sohyunnnn": ["u-zzn", "odukong"],
+              "odukong": ["u-zzn", "Sohyunnnn"],
             };
 
             const reviewers = reviewerMap[author];

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -15,6 +15,9 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Check Labels
         id: labeler
         uses: jimschubert/labeler-action@v2


### PR DESCRIPTION
## 📌 Issue Number

> #275 

## 🔍 Changes

PR / Issue 관리 자동화를 위해 GitHub Actions 기반 workflow를 구성했습니다.

- PR / Issue 제목 기반 자동 라벨링 (labeler.yml)
- 작성자 기준 사용자 라벨 자동 부착 (유진 ୨ৎ / 소현 ୨ৎ / 수빈 ୨ৎ)
- PR 생성 시 reviewer 자동 지정 (본인 제외 2명 자동 지정)

## 📃 Describe
#### ✔️ 왜 PR / Issue 자동화를 도입했을까요?
지금까지는 PR / Issue 생성 이후에 label, assignee, reviewer을 수동으로 지정해왔습니다.
이 과정을 각각 따로 진행해야 하고, PR / Issue를 생성할 때마다 매번 이 흐름을 반복하다보니 자동화를 통해 불필요한 노력을 줄일 수 있다고 생각했습니다 💪

---
#### ✔️ label / assignee / reviewer 자동화 구조
PR / Issue 생성 시 필요한 메타 정보를 한 번에 자동 설정하도록 구성했습니다.

label은 `labeler.yml`을 통해 제목 기반으로 자동 분류되도록 했습니다.
```YAML
labels:
  "Feature":
    include: ['\\bFeat\\b', '\\bfeat\\b']
```

작성자는 자동으로 assignee에 할당되도록 처리했습니다.
```js
assignees: [author]
```

reviewer는 작성자를 제외한 나머지 팀원들이 자동으로 지정되도록 구성했습니다.
전체 팀원 목록을 `allMembers` 배열로 관리하고, PR 작성자인 `author`만 제외한 나머지 인원을 reviewer로 지정하는 방식입니다.

**☑️ reviewer 동작 예시**

- u-zzn(유진)이 PR 생성 → Sohyunnnn(소현), odukong(수빈) reviewer 지정
- Sohyunnnn(소현)이 PR 생성 → u-zzn(유진), odukong(수빈) reviewer 지정
- odukong(수빈)이 PR 생성 → u-zzn(유진), Sohyunnnn(소현) reviewer 지정

```js
const allMembers = ["u-zzn", "Sohyunnnn", "odukong"]; 
const reviewers = allMembers.filter((member) => member !== author);
```

---

#### ✔️ 왜 jimschubert/labeler-action을 선택했을까요?
현재 자동화의 목적은 **PR 제목 기반으로 타입 라벨을 자동 분류**하는 것이기 때문에 
- GitHub 공식 `actions/labeler` (파일 경로 기반)
- jimschubert/labeler-action (텍스트 기반)

중에서 후자를 선택했습니다.

즉, 단순히 어떤 파일이 변경되었는지를 기준으로 분류하기보다는, 각 PR이 어떤 목적과 의도를 가지고 작성되었는지를 가장 직접적으로 드러내는 정보가 제목이라고 판단했습니다. 따라서 파일 경로 기반 분류보다, 작성자가 명시한 PR 제목을 기준으로 라벨을 부여하는 방식이 현재 띵스룸 협업 흐름과 더 잘 맞는다고 생각했습니다!

---

#### ✔️ `jimschubert/labeler-action@v2`: 버전을 v2로 선택한 이유
원래는 v1으로 설정하고자 하였지만, 기존 v1은 outdated 상태여서 최신 환경에서 안정적으로 동작하지 않을 수 있다고 판단했습니다. 
그래서 현재 유지보수가 계속 이루어지고 있는 최신 버전(v2)을 사용하는 것이 더 안전하다고 생각했고, 앞으로 GitHub 환경이 바뀌더라도 문제없이 사용할 수 있도록 v2로 적용했습니다!

---

#### ✔️ 왜 `pull_request_target`으로 지정했을까요?
원래는 `pull_request` 이벤트를 사용하고자 하였지만, 찾아보니 fork에서 올라온 PR에서는 권한 제한으로 인해 하고자 하는 label 추가, assignee 지정, reviewer 요청이 정상적으로 동작하지 않을 수 있다는 것을 알게 되었습니다.

그래서 base repo 권한으로 실행되는 pull_request_target으로 변경해서 모든 PR에서 동일하게 자동화가 동작하도록 구성했습니다.

---

✔️ 작성자 라벨을 별도로 처리한 이유
```js
const userLabels = {"u-zzn": "유진 ୨ৎ", "Sohyunnnn": "소현 ୨ৎ", "odukong": "수빈 ୨ৎ",};
```

labeler.yml은 PR 제목이나 Issue 내용처럼 텍스트 기반으로 라벨을 매칭하는 구조이기 때문에, “누가 작성했는지”와 같은 사용자 정보까지는 처리할 수 없습니다.

따라서 
- labeler.yml → PR 제목 기반으로 타입 라벨(Feature, Fix 등) 처리
- github-script → 작성자 정보를 기반으로 사용자 라벨 처리

이렇게 역할을 분리하고자 하였습니다.


## 👀 To Reviewer
- PR 제목 기반 라벨링을 위해 `jimschubert/labeler-action`을 사용했는데, 이 방식이 협업 흐름에 적절한지
- 안정성을 고려해 v2 버전을 사용했는데, 해당 선택이 괜찮은지
- fork PR까지 대응하기 위해 pull_request_target을 사용했는데, 보안/운영 측면에서 문제 없는지

이번 작업에서 몇 가지 선택한 방향에 대해 의견 부탁드립니다 🙇

- assign / reviewer 실행 시점 관련해서 현재는 `opened, reopened, synchronize, edited` 이벤트 모두에서 실행되도록 설정해두었습니다. PR이 수정될 때마다 반복 호출이 발생할 수 있는 구조인데, 이 부분을 그대로 유지하는 것이 좋을지, 아니면 `opened` 시점으로 제한하는 것이 더 나을지도 의견 부탁드립니다!

그리고 마지막으로, 만약 나중에 테스트 코드를 작성할 일이 생기거나 QA 관련 작업이 늘어나면 Test 라벨을 별도로 두는 것도 고려해볼 수 있을 것 같은데 이에 대해서도 의견 부탁드립니다! :)



## 📸 Screenshot
PR/Issue 생성 시 github-actions가 자동 추적해 label, assignee 제대로 지정되는거 개인 레포에서 test 완료했습니다 :)
반영되는데에는 시간이 좀 걸립니다 😥

> PR

https://github.com/user-attachments/assets/fddbadcf-4f36-4e5b-91fb-ccc497844a5f

> Issue

https://github.com/user-attachments/assets/82dcbcea-55e4-4d6e-8c23-d386f1c0edc9




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 이슈 및 PR 자동 레이블링 도입(여러 라벨 그룹과 키워드 기반 매칭)
  * 이벤트 기반 자동 검토자 요청 설정(작성자 제외한 사전 정의된 검토자 지정)

* **Chores**
  * 이슈 및 PR 작성자 자동 할당 추가
  * 관련 GitHub 워크플로우 및 레이블러 구성 파일 추가로 자동화 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->