### PR TITLE
[Chore] CI 구축 및 Vercel 배포 후 fork sync 자동화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,20 +22,11 @@ jobs:
         with:
           version: 10
 
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-pnpm-
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20.x"
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -26,14 +26,14 @@ jobs:
         id: pnpm-cache
         run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v4
         with:
           node-version: "20.x"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Check project
         id: check_step
-        run: pnpm run lint && pnpm exec tsc --noEmit
+        run: pnpm run lint && pnpm run typecheck
         continue-on-error: true
 
       - name: Build project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,109 @@
+name: ci
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v5
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20.x"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check project
+        id: check_step
+        run: pnpm run lint && pnpm exec tsc --noEmit
+        continue-on-error: true
+
+      - name: Build project
+        id: build_step
+        run: pnpm run build
+        continue-on-error: true
+
+      - name: Output build result
+        if: github.event_name == 'pull_request' && always()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: build-result
+          message: |
+            ### 🚀 빌드 결과
+            ${{ steps.check_step.outcome == 'success' && '🩵 린트 검사 완료' || '😥 린트 검사 실패' }}
+            ${{ steps.build_step.outcome == 'success' && '💙 빌드 성공' || '😭 빌드 실패' }}
+
+            <details>
+              <summary>✔️ 로그 확인하기</summary>
+              <br>
+              <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}">
+                Actions 탭에서 자세히 보기!
+              </a>
+            </details>
+
+      - name: Notify Discord Alarm
+        if: github.event_name == 'pull_request' && always()
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_USER="${{ github.event.pull_request.user.login }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+
+          if [ "${{ steps.build_step.outcome }}" == "success" ]; then
+            COLOR=3066993
+            TITLE="💙 빌드 성공"
+          else
+            COLOR=15158332
+            TITLE="😭 빌드 실패"
+          fi
+
+          DESCRIPTION="**📄 Title : \`$PR_TITLE\`\n ✏️ 작성자 : \`$PR_USER\`\n\n[🔎 PR보러가기]($PR_URL)"
+          curl -H "Content-Type: application/json" \
+               -d "{
+                 \"embeds\": [{
+                   \"title\": \"$TITLE\",
+                   \"description\": \"$DESCRIPTION\",
+                   \"color\": $COLOR
+                 }]
+               }" \
+               "${{ secrets.DISCORD_WEBHOOK_URL }}"
+
+      - name: Check Build Status
+        if: steps.check_step.outcome == 'failure' || steps.build_step.outcome == 'failure'
+        run: exit 1
+
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: auto-assign-author-and-reviewer
+        if: github.event_name == 'pull_request' && github.event.action == 'opened'
+        uses: hkusu/review-assign-action@v1
+        with:
+          assignees: ${{ github.actor }}
+          reviewers: u-zzn, jogpfls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
             TITLE="😭 빌드 실패"
           fi
 
-          DESCRIPTION="**📄 Title : \`$PR_TITLE\`\n ✏️ 작성자 : \`$PR_USER\`\n\n[🔎 PR보러가기]($PR_URL)"
+          DESCRIPTION="📄 Title : \`$PR_TITLE\`\n ✏️ 작성자 : \`$PR_USER\`\n\n[🔎 PR보러가기]($PR_URL)"
           curl -H "Content-Type: application/json" \
                -d "{
                  \"embeds\": [{

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,13 +90,3 @@ jobs:
       - name: Check Build Status
         if: steps.check_step.outcome == 'failure' || steps.build_step.outcome == 'failure'
         run: exit 1
-
-  assign:
-    runs-on: ubuntu-latest
-    steps:
-      - name: auto-assign-author-and-reviewer
-        if: github.event_name == 'pull_request' && github.event.action == 'opened'
-        uses: hkusu/review-assign-action@v1
-        with:
-          assignees: ${{ github.actor }}
-          reviewers: u-zzn, jogpfls

--- a/.github/workflows/vercel-sync.yml
+++ b/.github/workflows/vercel-sync.yml
@@ -28,7 +28,7 @@ jobs:
           echo "deployment_url: ${{ github.event.client_payload.url }}"
 
       - name: Checkout fork repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.FORK_SYNC_TOKEN }}
 

--- a/.github/workflows/vercel-sync.yml
+++ b/.github/workflows/vercel-sync.yml
@@ -1,0 +1,41 @@
+name: vercel-sync-after-success
+
+on:
+  repository_dispatch:
+    types: [vercel.deployment.success]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-fork:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.client_payload.environment == 'production' &&
+        github.event.client_payload.git_ref == 'refs/heads/main'
+      )
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Debug Vercel payload
+        run: |
+          echo "event: ${{ github.event.action }}"
+          echo "environment: ${{ github.event.client_payload.environment }}"
+          echo "git_ref: ${{ github.event.client_payload.git_ref }}"
+          echo "deployment_url: ${{ github.event.client_payload.url }}"
+
+      - name: Checkout fork repository
+        uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.FORK_SYNC_TOKEN }}
+
+      - name: Sync upstream -> fork
+        uses: tgymnich/fork-sync@v2.3.1
+        with:
+          github_token: ${{ secrets.FORK_SYNC_TOKEN }}
+          owner: u-zzn
+          base: main
+          head: main

--- a/.github/workflows/vercel-sync.yml
+++ b/.github/workflows/vercel-sync.yml
@@ -1,38 +1,24 @@
-name: vercel-sync-after-success
+name: sync-fork-for-vercel-deploy
 
 on:
-  repository_dispatch:
-    types: [vercel.deployment.success]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   sync-fork:
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event.client_payload.environment == 'production' &&
-        github.event.client_payload.git_ref == 'refs/heads/main'
-      )
     runs-on: ubuntu-latest
 
     steps:
-      - name: Debug Vercel payload
-        run: |
-          echo "event: ${{ github.event.action }}"
-          echo "environment: ${{ github.event.client_payload.environment }}"
-          echo "git_ref: ${{ github.event.client_payload.git_ref }}"
-          echo "deployment_url: ${{ github.event.client_payload.url }}"
-
-      - name: Checkout fork repository
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.FORK_SYNC_TOKEN }}
 
-      - name: Sync upstream -> fork
+      - name: Sync upstream -> fork (u-zzn)
         uses: tgymnich/fork-sync@v2.3.1
         with:
           github_token: ${{ secrets.FORK_SYNC_TOKEN }}


### PR DESCRIPTION
## 📌 Issue Number

> #276 

## 🔍 Changes

GitHub Actions 기반으로 CI 파이프라인 구성 + Vercel 배포 이후 fork 동기화 자동화를 추가했습니다.

- PR / push 시 lint → typecheck → build 자동 검증 (ci.yml)
- PR 빌드 결과를 sticky comment로 자동 업데이트
- Discord 웹훅을 통한 빌드 결과 알림
- 동일 브랜치 중복 CI 실행 방지 (concurrency)
- Vercel production 배포 성공 시 fork 레포 자동 동기화 (vercel-sync.yml)
- 기존 labeler와 중복되던 assign/reviewer 자동화 제거

## 📃 Describe

#### ✔️ 왜 CI/CD 자동화를 도입했을까요?
지금까지는 PR을 올린 후에 빌드가 정상 동작하는지, 린트나 타입 오류가 없는지 수동으로 확인해야 했습니다. 이 과정은 사람이 매번 수동으로 진행하기에는 반복적이고, 놓치기 쉬운 부분이 많다고 생각했습니다.
또한 현재 띵스룸은 Vercel 배포 + 개인 fork 기반 작업 구조를 사용하고 있기 때문에 배포 이후 fork와의 동기화도 수동으로 관리해야 하는 불편함이 있었습니다 😥

그래서 PR 단계에서 코드 품질을 자동 검증하고, 배포 이후 fork 상태까지 자동으로 맞추는 **CI + 배포 후 후처리 자동화 구조를 도입**하게 되었습니다 💪

---

#### ✔️ CI 파이프라인 구조 (ci.yml)
PR 및 main/develop 브랜치에 대해 아래 순서로 자동 검증이 수행됩니다.
```YAML
lint → typecheck → build
```

**☑️ 트리거 전략**
```YAML
on:
  push:
    branches: [main, develop]
  pull_request:
    branches: [main, develop]
```
현재 브랜치 전략 기준으로 보면
- `develop` → 기능 통합 및 테스트 단계
- `main` → 실제 배포 기준 브랜치

이 두 브랜치는 모두 코드 안정성이 중요한 구간이기 때문에 PR 또는 push 시 CI를 통해 반드시 검증이 필요하다고 판단했습니다.
반면, feature 브랜치까지 CI를 모두 실행할 경우 잦은 push로 인해 불필요한 Actions 실행이 증가하고 로그 관리가 복잡해질 것 같아서 `develop` 브랜치와 `main` 브랜치에만 CI 검증을 적용했습니다. 

**☑️ concurrency 설정**
```YAML
concurrency:
  group: ci-${{ github.ref }}
  cancel-in-progress: true
```
같은 브랜치에서 여러 번 push가 발생하면 이전 CI를 자동으로 취소하여 가장 최신 커밋 기준의 CI 결과만 확인할 수 있도록 했습니다.
`github.ref` 기준으로 브랜치별 CI 그룹을 만들고, 새로운 push가 들어오면 기존 실행을 자동 취소하도록 설정했습니다.

**☑️ pnpm 캐시 최적화**
기존에는 `actions/cache`를 사용해 pnpm store 경로를 직접 구하고, 캐시 key까지 수동으로 설정해야 했습니다.
이번 작업을 통해 `actions/setup-node@v4`의 내장 캐시 옵션을 사용해 설정을 간소화했습니다.
```YAML
uses: actions/setup-node@v4
with:
  cache: "pnpm"
```
`pnpm-lock.yaml` 기준으로 의존성 캐시가 관리되기 때문에, 불필요한 설치 시간을 줄이면서도 워크플로우 설정을 더 간단하게 유지할 수 있도록 했습니다 :)

**☑️ typecheck 스크립트 재사용**
```Bash
pnpm run lint && pnpm run typecheck
```
`tsc --noEmit`을 CI에서 직접 실행하는 대신, `package.json`에 정의된 `typecheck` 스크립트를 재사용하도록 했습니다.
이렇게 하면 로컬에서 실행하는 검사 방식과 CI에서 실행하는 검사 방식이 동일해지고, 나중에 typecheck 옵션이 변경되더라도 `package.json`만 수정하면 되어 유지보수가 더 쉬워진다고 생각했습니다!


**☑️ PR 결과 자동 코멘트**
```YAML
marocchino/sticky-pull-request-comment
```
PR에서 CI가 실행될 때마다 lint / build 결과를 코멘트로 남기도록 설정했습니다.

일반 코멘트 방식은 push할 때마다 새로운 코멘트가 계속 쌓일 수 있지만, `sticky-pull-request-comment`는 동일한 header의 코멘트를 덮어쓰는 방식으로 동작합니다.
결과적으로 PR에는 항상 가장 최신 CI 결과 하나만 유지됩니다!

**☑️ Discord 알림**
PR 기준으로만 Discord 알림이 전송되도록 설정했습니다.
전에 타 프로젝트에서 작업할 때 commit마다 알림을 보냈었는데, push가 여러 번 발생할 때마다 Discord 메시지가 계속 쌓여서 개별 commit보다는 PR 단위로 빌드 성공/실패 상태를 공유해도 괜찮지 않을까? 생각했습니다.

이제 GitHub Actions 탭을 직접 확인하지 않아도, Discord에서 PR의 검증 상태를 빠르게 확인하실 수 있습니다 :)
혹시 알림 단위를 commit 별로 변경하는 것이 더 좋으면 알려주세요 ☺️

**☑️ assign job 제거**
처음에는 CI workflow 안에서도 reviewer / assignee를 자동 지정하도록 코드를 구현했지만, 이미 사전에 작업한 `labeler.yml`에서 동일한 역할을 처리하고 있었습니다.

두 workflow에서 같은 작업을 동시에 수행할 필요가 없다고 생각했고, CI의 목적도 코드 검증이 아닌 PR 관리 자동화까지 섞이게 된다고 판단했습니다.

그래서 reviewer / assignee 지정은 `labeler.yml`에서만 담당하도록 정리하고, CI에서는 lint / typecheck / build 같은 순수 검증 역할만 수행하도록 분리했습니다 :)

---

#### ✔️ Vercel 배포 후 fork 자동 동기화 (vercel-sync.yml)
**☑️ 왜 필요한가?**
현재 띵스룸은 아래와 같은 구조로 운영되고 있습니다.

- 조직 레포 → 개발 진행
- 개인 fork → Vercel 배포 연결

이 구조에서는 조직 레포의 `main` 브랜치에 변경사항이 머지되더라도, 개인 fork 레포가 자동으로 최신 상태로 맞춰지지 않아서 배포 이후 개인 fork에서 직접 sync를 맞춰줘야 했기 때문에, 누락 가능성도 있고 반복 작업이 불필요하게 계속 발생한다고 생각해왔습니다 😥

그래서 Vercel 배포가 성공한 이후, 개인 fork 레포도 자동으로 최신 상태가 되도록 동기화 작업을 추가했습니다!

**☑️ 트리거 방식**
```YAML
repository_dispatch:
  types: [vercel.deployment.success]
```
Vercel에서 배포가 성공했을 때 전달되는 `vercel.deployment.success` 이벤트를 기준으로 workflow가 실행되도록 설정했습니다.
즉, 단순히 `main`에 머지되었을 때 바로 sync하는 것이 아니라, **Vercel 배포가 성공한 이후에 fork sync가 실행**되도록 구성했습니다!

또한 `workflow_dispatch`도 함께 추가하여, 초기 테스트나 sync가 누락된 경우에는 GitHub Actions 탭에서 수동으로 실행할 수 있도록 했습니다 :)

**☑️ 실행 조건**
```YAML
production + main 브랜치만 동작
```
Vercel은 PR 생성 시에도 preview 배포를 생성하기 때문에, 모든 배포 성공 이벤트에 반응하면 PR preview 배포 때마다 fork sync가 반복될 수 있다는 것을 작업 하면서 새롭게 알게 되었습니다.

fork 동기화는 실제 배포 기준인 `main` 브랜치의 production 배포 이후에만 필요하다고 판단해서 `production` 환경이면서 `main` 브랜치에서 발생한 배포 성공 이벤트일 때만 동작하도록 조건을 제한했습니다!


**☑️ fork 동기화 방식**
```YAML
tgymnich/fork-sync
```
fork 동기화는 `tgymnich/fork-sync` 액션을 사용하도록 구성했습니다.

기본 `GITHUB_TOKEN`만으로는 개인 fork 레포에 접근하거나 push 권한이 부족할 수 있기 때문에, 별도로 발급한 `FORK_SYNC_TOKEN`을 GitHub Secrets에 등록하여 사용하도록 했습니다.

이를 통해 Vercel 배포 성공 이후 `upstream → fork` 방향으로 자동 동기화가 이루어지도록 했습니다!

**☑️ Debug step 추가**
초기 연동 단계에서는 Vercel에서 전달되는 webhook payload가 예상한 형태로 들어오는지 확인이 필요하다고 판단했습니다.
그래서 `environment`, `git_ref`, `deployment_url` 등의 값을 Actions 로그에 출력하도록 Debug step을 추가했습니다.
이를 통해 `production` 배포인지, `main` 브랜치 기준 배포인지, 배포 URL이 정상적으로 전달되는지 확인할 수 있습니다.
추후 webhook 동작이 안정적으로 확인되면 해당 step은 제거하거나 유지 여부를 다시 검토할 수 있을 것 같습니다 🙂

**☑️ GitHub Actions 버전 수정**
초기에는 `actions/checkout@v5`, `actions/setup-node@v5`처럼 `@v5` 버전을 사용하고자 했습니다.

하지만 GitHub Actions는 각 action마다 개별적으로 버전이 관리되기 때문에, 모든 action이 동일하게 최신 버전을 제공하지는 않습니다. 현재 기준에서 안정적으로 사용할 수 있는 버전은 `@v4`였으며, `@v5`는 해당 action에서 제공되지 않아 workflow 실행 시 오류가 발생할 수 있었습니다.

| 항목 | v5 | v4 |
|------|----|----|
| 버전 존재 여부 | ❌ 해당 action에서 미지원 | ✅ 공식 제공 버전 |
| 릴리즈 상태 | 정의되지 않음 | 안정적인 stable 버전 |
| 버전 관리 방식 | 사용 불가 (레포에 존재하지 않음) | GitHub에서 관리되는 주요 릴리즈 |
| 사용 가능성 | 실행 시 action not found 오류 발생 | 정상 실행 가능 |

따라서 실제 사용 가능한 stable 버전인 `@v4`로 수정하여, workflow가 정상적으로 동작하도록 구성했습니다 :)

**☑️ pnpm 버전 관리 방식 개선**
초기에는 workflow 안에서 pnpm 버전을 직접 지정하려고 했지만,  이미 `package.json`에 `packageManager` 필드로 pnpm 버전이 명시되어 있었습니다.

그래서 workflow에서 `version`을 하드코딩하지 않고, `package.json`의 `packageManager` 값을 기준으로 pnpm 버전이 결정되도록 수정했습니다.

---


#### ✔️ 왜 CD 워크플로우를 따로 만들지 않았을까요?
초기에는 GitHub Actions 기반으로 `cd.yml`을 별도로 구성하여 배포까지 자동화하는 방향을 고려했습니다.
하지만 현재 띵스룸은 Vercel과 개인 fork 레포가 연결된 구조로 이미 운영되고 있었기 때문에, 일반적인 CD 파이프라인을 그대로 적용하는 것은 적절하지 않다고 판단했습니다.

현재 구조에서는 코드가 main 브랜치에 머지되면 Vercel이 자동으로 build와 deploy를 수행하고, 실제 서비스 배포 역시 Vercel이 담당하고 있습니다. 즉, 배포 자체는 이미 완전히 자동화되어 있는 상태이기 때문에, GitHub Actions에서 다시 배포(CD)를 구성하면 역할이 중복되는 구조가 됩니다.

또한 띵스룸은  이미  개인 fork 레포를 기반으로 배포가 이루어지는 흐름으로 이루어져 있는 상황이기에, 단순히 “배포를 실행하는 CD”보다 배포 이후 fork 레포의 상태를 최신으로 맞춰주는 후처리 작업이 더 중요한 상황이라고 판단했습니다.

이러한 이유로 CD 워크플로우를 따로 두는 대신,

- CI → 코드 품질 검증 (ci.yml)
- CD → Vercel이 담당
- 배포 이후 처리 → fork sync (vercel-sync.yml)

와 같이 역할을 분리하고, Vercel 배포 성공 이후에 fork 레포를 자동 동기화하는 vercel-sync.yml을 별도로 구성하게 되었습니다!

하나의 워크플로우에서 build와 deploy를 모두 처리하는 방식이 아니라, 현재 띵스룸 구조에 맞게 “배포는 Vercel에 맡기고, GitHub Actions는 검증과 후처리에 집중하는 구조”로 설계하는 것이 더 적절하다고 생각했습니다 ☺️

## 👀 To Reviewer
- CI 단계에서 build까지 포함하는 것이 적절한지, 아니면 Vercel에 맡기는게 더 나은지
- `concurrency` 설정이 현재 띵스룸 서비스 규모에서 적절한지
- Discord 알림을 PR 기준으로만 보내는 구조가 괜찮은지 (세세하게 commit 별로 전부 보내는 구조가 더 나을까욤? 🤔)
- Vercel 배포 성공 이후 `vercel-sync.yml`로 개인 fork를 동기화하는 방식이 안정적인지

확인 부탁드립니다 🙂

또한 현재는 배포 이후 sync를 맞춰야 하는 구조를 기준으로 자동화를 구성했는데, 해당 방식을 제거하고 **처음부터 조직 레포 기준으로 CD 플로우를 다시 구축**하는 것이 더 나을지도 함께 의견 부탁드립니다 🙇

## 📸 Screenshot

> PR 빌드 결과 자동 코멘트

<img width="912" height="435" alt="image" src="https://github.com/user-attachments/assets/5b8219ea-cd2b-4aed-ba64-8c2f0f813b32" />

> Discord 알림 정상 동작

<img width="320" height="288" alt="image" src="https://github.com/user-attachments/assets/e2ebf123-cdcf-4a97-b7c8-842d4d7ffbde" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
* CI 자동화 워크플로우 추가: 푸시/PR에서 린트·타입체크·빌드 실행 및 결과 요약을 PR에 자동 게시
* 빌드 상태 알림 개선: Discord 웹훅으로 빌드/타입체크 결과 알림 전송
* 실패 감지 강화: 린트·빌드 결과에 따른 전체 빌드 상태 체크 추가(문제 발생 시 워크플로우 실패)
* 포크 동기화 워크플로우 추가: 메인 브랜치 동기화 자동화 및 수동 실행 지원
<!-- end of auto-generated comment: release notes by coderabbit.ai -->