### PR TITLE
[Feat] 드롭다운 공통 컴포넌트 구현

### DIFF
--- a/src/app/suggest/history/[id]/page.jsx
+++ b/src/app/suggest/history/[id]/page.jsx
@@ -11,21 +11,8 @@ import axiosInstance from '@api/instance';
 import SuggestionImagesByUrl from '../../../../components/admin/SuggestionImagesByUrl';
 import useTokenStore from '../../../../stores/useTokenStore';
 
-const CATEGORIES = [
-  '분실물',
-  '기물 파손',
-  '시설 고장',
-  '소음 공해',
-  '미예약 사용자 신고',
-  '기타',
-];
-const PLACES = [
-  '스터디룸1',
-  '스터디룸2',
-  '스터디룸3',
-  '스터디룸4',
-  '스터디룸5',
-];
+import Dropdown from '@components/common/dropdown';
+import { categories, places } from '@constants/select-options';
 
 function BottomSafeSpacer({ height = 64 }) {
   return (
@@ -180,8 +167,8 @@ export default function SuggestHistoryDetailPage({ params }) {
   const [editing, setEditing] = useState(false);
   const [eTitle, setETitle] = useState('');
   const [eContent, setEContent] = useState('');
-  const [eCategory, setECategory] = useState(CATEGORIES[0]);
-  const [eLocation, setELocation] = useState(PLACES[0]);
+  const [eCategory, setECategory] = useState(categories[0].value);
+  const [eLocation, setELocation] = useState(places[0].value);
   const [ackAnswerDone, setAckAnswerDone] = useState(false);
   const [saving, setSaving] = useState(false);
   const [opMsg, setOpMsg] = useState('');
@@ -244,8 +231,8 @@ export default function SuggestHistoryDetailPage({ params }) {
     }
     setETitle(detail.title || '');
     setEContent(detail.content || '');
-    setECategory(detail.category || CATEGORIES[0]);
-    setELocation(detail.location || PLACES[0]);
+    setECategory(detail.category || categories[0].value);
+    setELocation(detail.location || places[0].value);
     setAckAnswerDone(false);
     setEditing(true);
     setOpMsg('');
@@ -427,33 +414,21 @@ export default function SuggestHistoryDetailPage({ params }) {
                       <label className="block text-sm font-medium mb-1">
                         분류
                       </label>
-                      <select
+                      <Dropdown
+                        options={categories}
                         value={eCategory}
-                        onChange={(e) => setECategory(e.target.value)}
-                        className="w-full rounded border px-3 py-2 text-sm bg-white"
-                      >
-                        {CATEGORIES.map((c) => (
-                          <option key={c} value={c}>
-                            {c}
-                          </option>
-                        ))}
-                      </select>
+                        onChange={(value) => setECategory(value)}
+                      />
                     </div>
                     <div>
                       <label className="block text-sm font-medium mb-1">
                         장소
                       </label>
-                      <select
+                      <Dropdown
+                        options={places}
                         value={eLocation}
-                        onChange={(e) => setELocation(e.target.value)}
-                        className="w-full rounded border px-3 py-2 text-sm bg-white"
-                      >
-                        {PLACES.map((p) => (
-                          <option key={p} value={p}>
-                            {p}
-                          </option>
-                        ))}
-                      </select>
+                        onChange={(value) => setELocation(value)}
+                      />
                     </div>
                   </div>
 

--- a/src/app/suggest/page.jsx
+++ b/src/app/suggest/page.jsx
@@ -8,34 +8,14 @@ import PrivacyPolicyFooter from '@components/common/PrivacyPolicyFooter';
 
 import axiosInstance from '@api/instance';
 
+import Dropdown from '@components/common/dropdown';
+
+import { categories, places } from '@constants/select-options';
+
 const MAX_TITLE = 20;
 const MAX_CONTENT = 3000;
 const MAX_FILES = 5;
 const MAX_TOTAL_SIZE = 30 * 1024 * 1024;
-
-const categories = [
-  '분실물',
-  '기물 파손',
-  '시설 고장',
-  '소음 공해',
-  '미예약 사용자 신고',
-  '기타',
-];
-const places = [
-  '스터디룸 1',
-  '스터디룸 2',
-  '스터디룸 3',
-  '스터디룸 4',
-  '스터디룸 5',
-];
-const ALLOWED_LOCATIONS = [
-  '스터디룸1',
-  '스터디룸2',
-  '스터디룸3',
-  '스터디룸4',
-  '스터디룸5',
-];
-const normalizeLocation = (label) => String(label).replace(/\s+/g, '');
 
 function BottomSafeSpacer({ height = 64 }) {
   return (
@@ -50,8 +30,8 @@ const bytesToMB = (bytes) => (bytes / (1024 * 1024)).toFixed(1);
 export default function SuggestPage() {
   // const router = useRouter();
 
-  const [category, setCategory] = useState(categories[0]);
-  const [place, setPlace] = useState(places[0]);
+  const [category, setCategory] = useState(categories[0].value);
+  const [place, setPlace] = useState(places[0].value);
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [files, setFiles] = useState([]);
@@ -116,19 +96,11 @@ export default function SuggestPage() {
     null;
 
   async function createSuggestion() {
-    const normalizedLocation = normalizeLocation(place);
-
-    if (!ALLOWED_LOCATIONS.includes(normalizedLocation)) {
-      throw new Error(
-        `유효하지 않은 위치 값입니다: '${place}'. 유효한 값: ${ALLOWED_LOCATIONS.join(', ')}`,
-      );
-    }
-
     const payload = {
       suggest_title: title.trim(),
       suggest_content: content.trim(),
       category: String(category).trim(),
-      location: normalizedLocation,
+      location: place,
     };
 
     try {
@@ -344,7 +316,7 @@ export default function SuggestPage() {
 
   return (
     <div className="min-h-screen bg-white flex flex-col">
-      <header className="sticky top-0 z-10 bg-white/90 backdrop-blur border-b border-line">
+      <header className="sticky top-0 z-header bg-white/90 backdrop-blur border-b border-line">
         <div className="px-5 py-4">
           <h1 className="text-2xl font-semibold text-content">건의/신고</h1>
         </div>
@@ -377,28 +349,12 @@ export default function SuggestPage() {
             </label>
             <div className="px-4 pb-4">
               <div className="relative">
-                <select
+                <Dropdown
+                  options={categories}
                   value={category}
-                  onChange={(e) => setCategory(e.target.value)}
-                  className="w-full appearance-none rounded-lg border bg-surface-subtle px-4 py-3 pr-10 text-md"
-                >
-                  {categories.map((c) => (
-                    <option key={c} value={c}>
-                      {c}
-                    </option>
-                  ))}
-                </select>
-                <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2">
-                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-                    <path
-                      d="M6 9l6 6 6-6"
-                      stroke="#9b9998"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </span>
+                  onChange={(value) => setCategory(value)}
+                  placeholder="신고 카테고리"
+                />
               </div>
             </div>
           </section>
@@ -410,28 +366,12 @@ export default function SuggestPage() {
             </label>
             <div className="px-4 pb-4">
               <div className="relative">
-                <select
+                <Dropdown
+                  options={places}
                   value={place}
-                  onChange={(e) => setPlace(e.target.value)}
-                  className="w-full appearance-none rounded-lg border bg-surface-subtle px-4 py-3 pr-10 text-md"
-                >
-                  {places.map((p) => (
-                    <option key={p} value={p}>
-                      {p}
-                    </option>
-                  ))}
-                </select>
-                <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2">
-                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-                    <path
-                      d="M6 9l6 6 6-6"
-                      stroke="#9b9998"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </span>
+                  onChange={(value) => setPlace(value)}
+                  placeholder="건의/신고 장소를 선택해주세요"
+                />
               </div>
             </div>
           </section>

--- a/src/app/suggest/page.jsx
+++ b/src/app/suggest/page.jsx
@@ -125,9 +125,8 @@ export default function SuggestPage() {
 
   async function fetchLatestSuggestionId() {
     try {
-      const normalizedLocation = normalizeLocation(place);
       const res = await axiosInstance.get('/api/suggestions', {
-        params: { category, location: normalizedLocation },
+        params: { category, location: place },
       });
       const list = Array.isArray(res?.data?.suggestions)
         ? res.data.suggestions

--- a/src/components/common/dropdown.tsx
+++ b/src/components/common/dropdown.tsx
@@ -71,7 +71,7 @@ const Dropdown = ({
           <div
             ref={dropdownRef}
             style={{
-              position: 'absolute',
+              position: 'fixed',
               top: `${position.top + 8}px`,
               left: `${position.left}px`,
               width: `${position.width}px`,

--- a/src/components/common/dropdown.tsx
+++ b/src/components/common/dropdown.tsx
@@ -1,3 +1,5 @@
+'use-client';
+
 import { createPortal } from 'react-dom';
 
 import KeyboardArrowDownRoundedIcon from '@mui/icons-material/KeyboardArrowDownRounded';

--- a/src/components/common/dropdown.tsx
+++ b/src/components/common/dropdown.tsx
@@ -75,8 +75,9 @@ const Dropdown = ({
               top: `${position.top + 8}px`,
               left: `${position.left}px`,
               width: `${position.width}px`,
+              maxHeight: `calc(100vh - ${position.top + 32}px)`,
             }}
-            className={`max-h-[320px] p-4 overflow-y-auto [&::-webkit-scrollbar]:hidden border border-gray-200 rounded-lg bg-white ${variant === 'modal' ? 'z-modal' : 'z-dropdown'}`}
+            className={`p-4 overflow-y-auto [&::-webkit-scrollbar]:hidden border border-gray-200 rounded-lg bg-white ${variant === 'modal' ? 'z-modal' : 'z-dropdown'}`}
           >
             <ul
               role="listbox"

--- a/src/components/common/dropdown.tsx
+++ b/src/components/common/dropdown.tsx
@@ -1,4 +1,3 @@
-import { useState, useRef, useLayoutEffect, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 
 import KeyboardArrowDownRoundedIcon from '@mui/icons-material/KeyboardArrowDownRounded';
@@ -75,7 +74,7 @@ const Dropdown = ({
               left: `${position.left}px`,
               width: `${position.width}px`,
             }}
-            className={`max-h-[320px] p-4 overflow-y-auto [&::-webkit-scrollbar]:hidden border border-gray-200 rounded-lg bg-white ${variant == 'modal' ? 'z-modal' : 'z-dropdown'}`}
+            className={`max-h-[320px] p-4 overflow-y-auto [&::-webkit-scrollbar]:hidden border border-gray-200 rounded-lg bg-white ${variant === 'modal' ? 'z-modal' : 'z-dropdown'}`}
           >
             <ul
               role="listbox"

--- a/src/components/common/dropdown.tsx
+++ b/src/components/common/dropdown.tsx
@@ -53,7 +53,7 @@ const Dropdown = ({
         disabled={disabled}
       >
         <span className={`${disabled ? 'text-gray-200' : 'text-gray-700'}`}>
-          {!value
+          {value === null || value === undefined
             ? placeholder
             : (options.find((o) => o.value === value)?.label ?? value)}
         </span>

--- a/src/components/common/dropdown.tsx
+++ b/src/components/common/dropdown.tsx
@@ -1,0 +1,110 @@
+import { useState, useRef, useLayoutEffect, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+
+import KeyboardArrowDownRoundedIcon from '@mui/icons-material/KeyboardArrowDownRounded';
+import { useDropdown } from '@hooks/use-dropdown';
+
+interface DropdownOption {
+  value: string | number; // 실제 옵션 데이터
+  label?: string; // 화면에 보여질 텍스트
+}
+
+interface DropdownProps {
+  options: DropdownOption[]; // 드롭다운 데이터
+  value?: string | number; // 선택 옵션 데이터
+  onChange?: (value: string | number) => void; // 선택 데이터 변경함수
+  placeholder?: string; // 드롭다운 설명 기본 텍스트
+  disabled?: boolean; // 드롭다운 활성화 여부
+  variant?: 'default' | 'modal'; // 드롭다운 z-index (기본 드롭다운 default, 모달 내부 드롭다운 modal)
+}
+
+const Dropdown = ({
+  options,
+  value,
+  onChange,
+  placeholder = '선택',
+  disabled = false,
+  variant = 'default',
+}: DropdownProps) => {
+  const {
+    isOpen,
+    closeDropdown,
+    toggleDropdown,
+    triggerRef,
+    dropdownRef,
+    position,
+  } = useDropdown();
+
+  // 드롭다운 옵션 선택 함수
+  const handleSelected = (option: string | number) => {
+    onChange?.(option);
+    closeDropdown();
+  };
+
+  return (
+    <div className="relative w-full max-w-[532px]">
+      {/** 드롭다운 셀렉트 박스 */}
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-expanded={isOpen}
+        className={`flex justify-between items-center w-full px-4 py-3 bg-white border 
+          ${isOpen ? 'border-primary-200' : 'border-gray-200'} rounded-lg text-gray-700`}
+        onClick={toggleDropdown}
+        disabled={disabled}
+      >
+        <span className={`${disabled ? 'text-gray-200' : 'text-gray-700'}`}>
+          {!value
+            ? placeholder
+            : (options.find((o) => o.value === value)?.label ?? value)}
+        </span>
+        <KeyboardArrowDownRoundedIcon
+          className={`${isOpen ? '-rotate-180 text-gray-700' : 'text-gray-200 '}`}
+          sx={{ transition: 'transform 0.3s ease' }}
+        />
+      </button>
+
+      {/** 드롭다운 옵션 */}
+      {isOpen &&
+        createPortal(
+          <div
+            ref={dropdownRef}
+            style={{
+              position: 'absolute',
+              top: `${position.top + 8}px`,
+              left: `${position.left}px`,
+              width: `${position.width}px`,
+            }}
+            className={`max-h-[320px] p-4 overflow-y-auto [&::-webkit-scrollbar]:hidden border border-gray-200 rounded-lg bg-white ${variant == 'modal' ? 'z-modal' : 'z-dropdown'}`}
+          >
+            <ul
+              role="listbox"
+              aria-label={placeholder}
+              className="flex flex-col gap-3"
+            >
+              {options.map((option) => (
+                <li key={option.value} role="none">
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={value === option.value}
+                    className={`w-full px-4 py-3 rounded-lg text-left transition-colors ${
+                      value === option.value
+                        ? 'bg-primary-100 text-primary-500'
+                        : 'hover:bg-primary-100/30 text-gray-700'
+                    }`}
+                    onClick={() => handleSelected(option.value)}
+                  >
+                    {option.label ?? option.value}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
+};
+
+export default Dropdown;

--- a/src/components/reservation/ReservationComponent.jsx
+++ b/src/components/reservation/ReservationComponent.jsx
@@ -50,8 +50,8 @@ const toKSTISOString = (utcMs) =>
 
 const ReservationComponent = ({ index, roomId, roomName, caption, notice }) => {
   const [open, setOpen] = useState(false);
-  const [startTime, setStartTime] = useState('');
-  const [endTime, setEndTime] = useState('');
+  const [startTime, setStartTime] = useState(null);
+  const [endTime, setEndTime] = useState(null);
   const [durationMinutes, setDurationMinutes] = useState(null);
   const [showLoginModal, setShowLoginModal] = useState(false);
 

--- a/src/components/reservation/ReservationComponent.jsx
+++ b/src/components/reservation/ReservationComponent.jsx
@@ -168,8 +168,8 @@ const ReservationComponent = ({ index, roomId, roomName, caption, notice }) => {
       ]);
 
       setOpen(false);
-      setStartTime('');
-      setEndTime('');
+      setStartTime(null);
+      setEndTime(null);
       setDurationMinutes(null);
     } catch (err) {
       console.error('예약 실패:', err.response?.data || err.message);
@@ -338,7 +338,7 @@ const ReservationComponent = ({ index, roomId, roomName, caption, notice }) => {
                       setEndTime(candidateEnd);
                       setDurationMinutes(len);
                     } else {
-                      setEndTime('');
+                      setEndTime(null);
                     }
                   };
 
@@ -370,7 +370,11 @@ const ReservationComponent = ({ index, roomId, roomName, caption, notice }) => {
                     }
                   }
                 }}
-                placeholder={!startTime ? '예약시간 먼저 선택' : '선택'}
+                placeholder={
+                  endTimeOptions.length === 0 || !startTime
+                    ? '예약시간 먼저 선택'
+                    : '선택'
+                }
                 disabled={!startTime || endTimeOptions.length === 0}
                 variant="modal"
               />

--- a/src/components/reservation/ReservationComponent.jsx
+++ b/src/components/reservation/ReservationComponent.jsx
@@ -12,6 +12,8 @@ import axiosInstance from '@api/instance';
 import useReservationStore from '../../stores/useReservationStore';
 import useTokenStore from '../../stores/useTokenStore';
 
+import Dropdown from '@components/common/dropdown';
+
 // 타임존 안전 유틸 (KST = UTC+9, DST 없음)
 const KST_MS = 9 * 60 * 60 * 1000;
 const TEN_MIN = 10 * 60 * 1000;
@@ -194,43 +196,32 @@ const ReservationComponent = ({ index, roomId, roomName, caption, notice }) => {
     const options = [];
     for (let ms = rounded; ms <= endMs; ms += TEN_MIN) {
       if (!reserved10mKeys.has(slotKey10m(ms))) {
-        options.push(ms);
+        options.push({
+          label: formatTime(ms),
+          value: new Date(ms).toISOString(),
+        });
       }
     }
 
-    return options.map((ms) => {
-      const iso = new Date(ms).toISOString();
-      return (
-        <option key={iso} value={iso}>
-          {formatTime(ms)}
-        </option>
-      );
-    });
+    return options;
   };
 
   // 오늘 모달: 종료시간 후보(1h/2h) 중 충돌 없는 것만
   const renderEndTimeOptions = () => {
-    if (!startTime) {
-      return [];
-    }
+    if (!startTime) return [];
     const startMs = new Date(startTime).getTime();
-    const end1Ms = startMs + 60 * 60000;
-    const end2Ms = startMs + 120 * 60000;
     const startISO = new Date(startMs).toISOString();
 
-    const candidates = [end1Ms, end2Ms].filter((ms) =>
-      isRangeAvailable(startISO, new Date(ms).toISOString()),
-    );
-
-    return candidates.map((ms) => {
-      const iso = new Date(ms).toISOString();
-      return (
-        <option key={iso} value={iso}>
-          {formatTime(ms)}
-        </option>
-      );
-    });
+    return [startMs + 60 * 60000, startMs + 120 * 60000]
+      .filter((ms) => isRangeAvailable(startISO, new Date(ms).toISOString()))
+      .map((ms) => ({
+        label: formatTime(ms),
+        value: new Date(ms).toISOString(),
+      }));
   };
+
+  const startTimeOptions = renderStartTimeOptions();
+  const endTimeOptions = renderEndTimeOptions();
 
   // KST 오늘 날짜 표시용
   const todayKSTDisplay = () => {
@@ -334,11 +325,11 @@ const ReservationComponent = ({ index, roomId, roomName, caption, notice }) => {
 
             <div className="mb-3">
               <div>예약 시간</div>
-              <select
-                className="border rounded-md p-2 w-full"
+              <Dropdown
+                options={startTimeOptions}
                 value={startTime}
-                onChange={(e) => {
-                  const newStart = e.target.value;
+                onChange={(value) => {
+                  const newStart = value;
                   setStartTime(newStart);
 
                   const tryAuto = (len) => {
@@ -357,21 +348,18 @@ const ReservationComponent = ({ index, roomId, roomName, caption, notice }) => {
                     tryAuto(60);
                   }
                 }}
-              >
-                <option value="" disabled>
-                  시간 선택
-                </option>
-                {renderStartTimeOptions()}
-              </select>
+                placeholder="시간 선택"
+                variant="modal"
+              />
             </div>
 
             <div>
               <div>퇴실 시간</div>
-              <select
-                className="border rounded-md p-2 w-full"
+              <Dropdown
+                options={endTimeOptions}
                 value={endTime}
-                onChange={(e) => {
-                  const selectedEnd = e.target.value;
+                onChange={(value) => {
+                  const selectedEnd = value;
                   setEndTime(selectedEnd);
                   if (startTime) {
                     const dur =
@@ -382,13 +370,10 @@ const ReservationComponent = ({ index, roomId, roomName, caption, notice }) => {
                     }
                   }
                 }}
-                disabled={!startTime}
-              >
-                <option value="" disabled>
-                  {startTime === '' ? '예약 시간 먼저 선택' : '시간 선택'}
-                </option>
-                {renderEndTimeOptions()}
-              </select>
+                placeholder={!startTime ? '예약시간 먼저 선택' : '선택'}
+                disabled={!startTime || endTimeOptions.length == 0}
+                variant="modal"
+              />
             </div>
           </div>
         </Modal>

--- a/src/components/reservation/ReservationComponent.jsx
+++ b/src/components/reservation/ReservationComponent.jsx
@@ -371,7 +371,7 @@ const ReservationComponent = ({ index, roomId, roomName, caption, notice }) => {
                   }
                 }}
                 placeholder={!startTime ? '예약시간 먼저 선택' : '선택'}
-                disabled={!startTime || endTimeOptions.length == 0}
+                disabled={!startTime || endTimeOptions.length === 0}
                 variant="modal"
               />
             </div>

--- a/src/components/reservation/TomorrowReservationComponent.jsx
+++ b/src/components/reservation/TomorrowReservationComponent.jsx
@@ -60,8 +60,8 @@ const TomorrowReservationComponent = ({
   notice,
 }) => {
   const [open, setOpen] = useState(false);
-  const [startTime, setStartTime] = useState('');
-  const [endTime, setEndTime] = useState('');
+  const [startTime, setStartTime] = useState(null);
+  const [endTime, setEndTime] = useState(null);
   const [durationMinutes, setDurationMinutes] = useState(null);
   const [showLoginModal, setShowLoginModal] = useState(false);
 

--- a/src/components/reservation/TomorrowReservationComponent.jsx
+++ b/src/components/reservation/TomorrowReservationComponent.jsx
@@ -171,8 +171,8 @@ const TomorrowReservationComponent = ({
       ]);
 
       setOpen(false);
-      setStartTime('');
-      setEndTime('');
+      setStartTime(null);
+      setEndTime(null);
       setDurationMinutes(null);
     } catch (err) {
       console.error('예약 실패:', err.response?.data || err.message);
@@ -322,7 +322,7 @@ const TomorrowReservationComponent = ({
                       setEndTime(candidateEnd);
                       setDurationMinutes(len);
                     } else {
-                      setEndTime('');
+                      setEndTime(null);
                     }
                   };
 
@@ -353,7 +353,11 @@ const TomorrowReservationComponent = ({
                     }
                   }
                 }}
-                placeholder={!startTime ? '예약시간 먼저 선택' : '선택'}
+                placeholder={
+                  endTimeOptions.length === 0 || !startTime
+                    ? '예약시간 먼저 선택'
+                    : '선택'
+                }
                 disabled={!startTime || endTimeOptions.length === 0}
                 variant="modal"
               />

--- a/src/components/reservation/TomorrowReservationComponent.jsx
+++ b/src/components/reservation/TomorrowReservationComponent.jsx
@@ -354,7 +354,7 @@ const TomorrowReservationComponent = ({
                   }
                 }}
                 placeholder={!startTime ? '예약시간 먼저 선택' : '선택'}
-                disabled={!startTime || endTimeOptions.length == 0}
+                disabled={!startTime || endTimeOptions.length === 0}
                 variant="modal"
               />
             </div>

--- a/src/components/reservation/TomorrowReservationComponent.jsx
+++ b/src/components/reservation/TomorrowReservationComponent.jsx
@@ -12,6 +12,8 @@ import axiosInstance from '@api/instance';
 import useReservationStore from '../../stores/useReservationStore';
 import useTokenStore from '../../stores/useTokenStore';
 
+import Dropdown from '@components/common/dropdown';
+
 //타임존 안전 유틸 (KST = UTC+9, DST 없음)
 const KST_MS = 9 * 60 * 60 * 1000;
 const TEN_MIN = 10 * 60 * 1000;
@@ -244,37 +246,28 @@ const TomorrowReservationComponent = ({
         }
         return !reserved10mKeys.has(slotKey10m(ms));
       })
-      .map((ms) => {
-        const iso = new Date(ms).toISOString();
-        return (
-          <option key={iso} value={iso}>
-            {formatTime(ms)}
-          </option>
-        );
-      });
+      .map((ms) => ({
+        label: formatTime(ms),
+        value: new Date(ms).toISOString(),
+      }));
 
   const renderEndTimeOptions = () => {
     if (!startTime) {
       return [];
     }
     const startMs = new Date(startTime).getTime();
-    const end1Ms = startMs + 60 * 60000;
-    const end2Ms = startMs + 120 * 60000;
     const startISO = new Date(startMs).toISOString();
 
-    const candidates = [end1Ms, end2Ms].filter((ms) =>
-      isRangeAvailable(startISO, new Date(ms).toISOString()),
-    );
-
-    return candidates.map((ms) => {
-      const iso = new Date(ms).toISOString();
-      return (
-        <option key={iso} value={iso}>
-          {formatTime(ms)}
-        </option>
-      );
-    });
+    return [startMs + 60 * 60000, startMs + 120 * 60000]
+      .filter((ms) => isRangeAvailable(startISO, new Date(ms).toISOString()))
+      .map((ms) => ({
+        label: formatTime(ms),
+        value: new Date(ms).toISOString(),
+      }));
   };
+
+  const startTimeOptions = renderStartTimeOptions();
+  const endTimeOptions = renderEndTimeOptions();
 
   return (
     <div className="flex flex-col justify-between p-4 sm:p-7 bg-white rounded-2xl w-full max-w-full mt-4">
@@ -316,11 +309,11 @@ const TomorrowReservationComponent = ({
             <div className="flex flex-col mt-4 mb-4">{renderTimeBlocks()}</div>
             <div className="mb-3">
               <div>예약 시간</div>
-              <select
-                className="border rounded-md p-2 w-full"
+              <Dropdown
+                options={startTimeOptions}
                 value={startTime}
-                onChange={(e) => {
-                  const newStart = e.target.value;
+                onChange={(value) => {
+                  const newStart = value;
                   setStartTime(newStart);
 
                   const tryAuto = (len) => {
@@ -339,20 +332,17 @@ const TomorrowReservationComponent = ({
                     tryAuto(60);
                   }
                 }}
-              >
-                <option value="" disabled>
-                  시간 선택
-                </option>
-                {renderStartTimeOptions()}
-              </select>
+                placeholder="시간 선택"
+                variant="modal"
+              />
             </div>
             <div>
               <div>퇴실 시간</div>
-              <select
-                className="border rounded-md p-2 w-full"
+              <Dropdown
+                options={endTimeOptions}
                 value={endTime}
-                onChange={(e) => {
-                  const selectedEnd = e.target.value;
+                onChange={(value) => {
+                  const selectedEnd = value;
                   setEndTime(selectedEnd);
                   if (startTime) {
                     const dur =
@@ -363,13 +353,10 @@ const TomorrowReservationComponent = ({
                     }
                   }
                 }}
-                disabled={!startTime}
-              >
-                <option value="" disabled>
-                  {startTime === '' ? '예약 시간 먼저 선택' : '시간 선택'}
-                </option>
-                {renderEndTimeOptions()}
-              </select>
+                placeholder={!startTime ? '예약시간 먼저 선택' : '선택'}
+                disabled={!startTime || endTimeOptions.length == 0}
+                variant="modal"
+              />
             </div>
           </div>
         </Modal>

--- a/src/constants/select-options.ts
+++ b/src/constants/select-options.ts
@@ -6,7 +6,7 @@ const categories = [
   { value: '소음공해', label: '소음 공해' },
   { value: '미예약사용자신고', label: '미예약 사용자 신고' },
   { value: '기타', label: '기타' },
-];
+] as const;
 
 /** 건의/신고 장소 */
 const places = [
@@ -15,6 +15,6 @@ const places = [
   { value: '스터디룸3', label: '스터디룸 3' },
   { value: '스터디룸4', label: '스터디룸 4' },
   { value: '스터디룸5', label: '스터디룸 5' },
-];
+] as const;
 
 export { categories, places };

--- a/src/constants/select-options.ts
+++ b/src/constants/select-options.ts
@@ -1,0 +1,20 @@
+/** 건의/신고 카테고리 */
+const categories = [
+  { value: '분실물', label: '분실물' },
+  { value: '기물파손', label: '기물 파손' },
+  { value: '시설고장', label: '시설 고장' },
+  { value: '소음공해', label: '소음 공해' },
+  { value: '미예약사용자신고', label: '미예약 사용자 신고' },
+  { value: '기타', label: '기타' },
+];
+
+/** 건의/신고 장소 */
+const places = [
+  { value: '스터디룸1', label: '스터디룸 1' },
+  { value: '스터디룸2', label: '스터디룸 2' },
+  { value: '스터디룸3', label: '스터디룸 3' },
+  { value: '스터디룸4', label: '스터디룸 4' },
+  { value: '스터디룸5', label: '스터디룸 5' },
+];
+
+export { categories, places };

--- a/src/hooks/use-dropdown.ts
+++ b/src/hooks/use-dropdown.ts
@@ -19,8 +19,8 @@ export const useDropdown = () => {
       if (triggerRef.current) {
         const ref = triggerRef.current.getBoundingClientRect();
         setPosition({
-          top: window.scrollY + ref?.bottom,
-          left: window.scrollX + ref?.left,
+          top: ref?.bottom,
+          left: ref?.left,
           width: ref.width,
         });
       }
@@ -36,11 +36,11 @@ export const useDropdown = () => {
     updatePosition(); // 처음 드롭다운 토글 시, 최초 계산
 
     window.addEventListener('resize', handleThrottle);
-    window.addEventListener('scroll', handleThrottle);
+    window.addEventListener('scroll', handleThrottle, true);
 
     return () => {
       window.removeEventListener('resize', handleThrottle);
-      window.removeEventListener('scroll', handleThrottle);
+      window.removeEventListener('scroll', handleThrottle, true);
       cancelAnimationFrame(rafId);
     };
   }, [isOpen]);

--- a/src/hooks/use-dropdown.ts
+++ b/src/hooks/use-dropdown.ts
@@ -2,7 +2,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 export const useDropdown = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const [position, setIsPosition] = useState({ top: 0, left: 0, width: 0 }); // 드롭다운 옵션 위치
+  const [position, setPosition] = useState({ top: 0, left: 0, width: 0 }); // 드롭다운 옵션 위치
 
   const triggerRef = useRef<HTMLButtonElement>(null); // 드롭다운 트리거
   const dropdownRef = useRef<HTMLDivElement>(null); // 드롭다운 옵션 ref
@@ -18,7 +18,7 @@ export const useDropdown = () => {
     const updatePosition = () => {
       if (triggerRef.current) {
         const ref = triggerRef.current.getBoundingClientRect();
-        setIsPosition({
+        setPosition({
           top: window.scrollY + ref?.bottom,
           left: window.scrollX + ref?.left,
           width: ref.width,
@@ -49,7 +49,7 @@ export const useDropdown = () => {
   useEffect(() => {
     if (!isOpen) return;
 
-    const handleOutSideClick = (e: MouseEvent) => {
+    const handleOutSideClick = (e: PointerEvent) => {
       const target = e.target as Node;
       if (
         triggerRef.current?.contains(target) ||

--- a/src/hooks/use-dropdown.ts
+++ b/src/hooks/use-dropdown.ts
@@ -1,0 +1,68 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+export const useDropdown = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [position, setIsPosition] = useState({ top: 0, left: 0, width: 0 }); // 드롭다운 옵션 위치
+
+  const triggerRef = useRef<HTMLButtonElement>(null); // 드롭다운 트리거
+  const dropdownRef = useRef<HTMLDivElement>(null); // 드롭다운 옵션 ref
+
+  const closeDropdown = () => setIsOpen(false);
+  const toggleDropdown = () => setIsOpen((pre) => !pre);
+
+  // 드롭다운 옵션 위치 계산 훅
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+
+    const updatePosition = () => {
+      if (triggerRef.current) {
+        const ref = triggerRef.current.getBoundingClientRect();
+        setIsPosition({
+          top: window.scrollY + ref?.bottom,
+          left: window.scrollX + ref?.left,
+          width: ref.width,
+        });
+      }
+    };
+
+    updatePosition(); // 처음 드롭다운 토글 시, 최초 계산
+
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition);
+
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition);
+    };
+  }, [isOpen]);
+
+  // 드롭다운 외부 영역 클릭 시 닫기 훅
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleOutSideClick = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (
+        triggerRef.current?.contains(target) ||
+        dropdownRef.current?.contains(target)
+      ) {
+        return;
+      }
+      closeDropdown();
+    };
+
+    document.addEventListener('pointerdown', handleOutSideClick);
+
+    return () =>
+      document.removeEventListener('pointerdown', handleOutSideClick);
+  }, [isOpen]);
+
+  return {
+    isOpen,
+    closeDropdown,
+    toggleDropdown,
+    triggerRef,
+    dropdownRef,
+    position,
+  };
+};

--- a/src/hooks/use-dropdown.ts
+++ b/src/hooks/use-dropdown.ts
@@ -14,6 +14,7 @@ export const useDropdown = () => {
   useLayoutEffect(() => {
     if (!isOpen) return;
 
+    // 드롭다운 옵션 위치 계산
     const updatePosition = () => {
       if (triggerRef.current) {
         const ref = triggerRef.current.getBoundingClientRect();
@@ -25,14 +26,22 @@ export const useDropdown = () => {
       }
     };
 
+    let rafId = 0;
+
+    const handleThrottle = () => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(updatePosition);
+    };
+
     updatePosition(); // 처음 드롭다운 토글 시, 최초 계산
 
-    window.addEventListener('resize', updatePosition);
-    window.addEventListener('scroll', updatePosition);
+    window.addEventListener('resize', handleThrottle);
+    window.addEventListener('scroll', handleThrottle);
 
     return () => {
-      window.removeEventListener('resize', updatePosition);
-      window.removeEventListener('scroll', updatePosition);
+      window.removeEventListener('resize', handleThrottle);
+      window.removeEventListener('scroll', handleThrottle);
+      cancelAnimationFrame(rafId);
     };
   }, [isOpen]);
 
@@ -52,7 +61,6 @@ export const useDropdown = () => {
     };
 
     document.addEventListener('pointerdown', handleOutSideClick);
-
     return () =>
       document.removeEventListener('pointerdown', handleOutSideClick);
   }, [isOpen]);

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -163,6 +163,8 @@ export default {
         'heading-xl': '32px',
       },
       zIndex: {
+        dropdown: '10',
+        header: '100',
         modal: '9999',
       },
       lineHeight: {


### PR DESCRIPTION
## 📌 Issue Number

close #289 


## 🔍 Changes

- 공통 `Dropdown` 컴포넌트 구현 및 기존 select 태그 교체
- 드롭다운(옵션) 위치 계산 및 외부 클릭 감지 로직을 `use-dropdown` 훅으로 분리

## 📃 Describe

기존에 사용하고 있던 select 태그들은 별도로 분리된 공통 컴포넌트 없이 파편화되어 있는 상태였습니다. 또한 기본 select 태그에 화살표 아이콘을 SVG 코드로 직접 삽입하는 방식으로 디자인을 커스텀하고 있어, 디자인 일관성과 코드 가독성 모두 떨어진다고 판단하였습니다. 이를 공통 `Dropdown` 컴포넌트를 구현하여 대체하도록 하였습니다.

### 구현된 드롭다운 공통 컴포넌트 (dropdown.tsx)

❓ **createPortal을 활용한 드롭다운 컴포넌트** 

드롭다운 컴포넌트의 옵션 목록은 **createPortal**을 사용해 **document.body**에 직접 렌더링할 수 있도록 구현하였습니다

건의/신고 페이지처럼 일반적인 레이어에서는 z-index만으로 옵션 목록이 다른 요소보다 높은 우선순위를 가지도록 제어가 가능하지만, 모달 내부(ex. 스터디룸 예약 모달)에서 사용되는 드롭다운은 모달보다 높은 레이어 우선순위를 가져야 합니다. 이때 모달 내부에서 옵션 리스트가 펼쳐지면 부모 요소의 overflow 제약 때문에 z-index가 적용되지 않고, 리스트가 잘리거나 모달 자체에 불필요한 스크롤이 생기는 문제가 발생합니다.

해당 문제를 해결하기 위해 **옵션 목록을 모달 내부가 아닌 document.body 하위 최상단에 렌더링되도록 처리**하였습니다. 

<img width="400" height="450" alt="드롭다운2-2" src="https://github.com/user-attachments/assets/8c3117eb-3e0c-48e4-a196-3e4a7f53c64d" />

<br/>

드롭다운 컴포넌트는 크게 아래와 같이 **props**를 받습니다. 

> - **options** : 드롭다운 옵션 데이터
> - **value** : 선택된 옵션 데이터
> - **onChange** : 선택 옵션을 변경하는 콜백 함수
> - **placeholder** : 선택된 값이 없는 초기 드롭다운에서 보여줄 텍스트
> - **disabled** : 드롭다운 비활성화 여부
> - **variant** : (‘default’,’modal’) 드롭다운 레이어 우선순위 제어

기존의 옵션(options) 데이터 타입은 단순 배열(array) 형태였습니다. 하지만 단순한 배열 타입을 가지게 되면, `화면에 보여지는 옵션 텍스트`와 `실제 서버로 보내지는 선택 옵션 텍스트`를 동일하게 사용해야 합니다. 만약 화면 텍스트와 서버로 보내는 데이터 타입이 다른 경우에는 전처리해주는 과정이 번거롭다고 생각하였고, 이를 해결하기 위해 options 타입을 아래와 같이 확장하여 사용할 수 있게 하였습니다. 

- **건의/신고 페이지**에서 사용되는 categories, places 데이터를 **문자열 배열 타입 →  DropdownOptions 타입**으로 변경하였으며, 해당 데이터들은 **constants/select-options.ts**로 분리하였습니다.

```tsx
interface DropdownOption {
	value: string | number; // 실제 옵션 데이터
	label?: string; // 화면에 보여질 텍스트
}
```

드롭다운 공통 컴포넌트를 구현함에 따라 기존에 select 태그를 사용하던 페이지를 수정하였습니다.

> - `건의/신고 페이지` - 분류, 장소 선택
> - `예약 모달` (오늘, 내일) - 예약 시간, 퇴실 시간 선택

### use-dropdown 훅

드롭다운 오픈/닫기 액션 및 드롭다운 외부 클릭 감지 액션, 드롭다운 옵션 위치 계산 로직을 컴포넌트와 분리하여 `hooks/use-dropdown`훅으로 구현하였습니다. 

**useLayoutEffect 내에서 getBoundingClientRect를 통해 드롭다운 트리거 버튼의 위치를 계산하고, 옵션 목록이 이에 맞춰 배치**될 수 있도록 했습니다. 

또한 **드롭다운 외부 영역이 클릭되면 드롭다운이 닫히는 액션**이 필요합니다. 마우스 클릭, 터치 이벤트를 모두 포함하는 pointerdown을 사용하여 PC/모바일 환경에 대응하도록 했습니다. 

💡 **옵션 위치 계산에 대한 성능 개선** 

드롭다운이 열린 상태에서 resize 및 scroll 이벤트가 연속적으로 발생할 경우, 이벤트마다 `getBoundingClientRect()`가 즉시 호출되면서 layout 계산이 반복적으로 발생하였습니다. 이로 인해 메인 스레드에서 불필요한 작업이 과도하게 수행(특히 scripting)되는 병목 현상을 확인하였습니다.

<img width="400" height="145" alt="image" src="https://github.com/user-attachments/assets/ec753701-45c4-4590-ab37-2a421b51401b" />

- Long Task: **240.82ms** (권장 기준 50ms 초과)
- Scripting: **177ms** — 전체의 약 74%를 JS 연산이 차지
- Rendering / Painting이 반복적으로 발생하며 레이아웃 재계산이 지속

이를 해결하기 위해 resize 및 scroll 이벤트가 발생할 때마다 즉시 위치를 재계산하지 않고, `requestAnimationFrame`을 활용하여 브라우저의 렌더링 사이클에 맞춰 위치 계산이 수행되도록 개선하였습니다. 

<img width="400" height="200" alt="image2" src="https://github.com/user-attachments/assets/93a2c6fd-ef15-4b09-a336-be80f8df8e29" />


requestAnimationFrame을 통해 연속적으로 발생하는 scroll/resize 이벤트를 브라우저 렌더링 타이밍에 맞춰 batching함으로써 불필요한 layout 계산과 scripting 비용을 줄였습니다.


## 👀 To Reviewer

-  드롭다운 컴포넌트를 구현함에 따라 수정된 페이지들이 있습니다. (건의/신고 페이지, 예약 모달) 
단순히 드롭다운 교체을 위해 코드를 수정한 부분이 있기 때문에 코드리뷰는 `dropdown.tsx`, `use-dropdown.ts` 위주로 봐주시면 될 것 같습니다. 

## 📸 Screenshot


<img width="400" height="320" alt="드롭다운1" src="https://github.com/user-attachments/assets/cfa35634-a07a-4a5c-9e9a-de3ccf6a6ef1" />
<img width="400" height="400" alt="드롭다운2" src="https://github.com/user-attachments/assets/12a03ddb-cd4d-41f7-8b22-2a0e507fc13c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 공통 Dropdown 컴포넌트 및 드롭다운 훅 추가 — 앱 전반에 일관된 선택 UI 제공

* **개선 사항**
  * 건의/신고와 예약 페이지의 기존 select를 Dropdown으로 교체하여 사용성 향상
  * 카테고리·장소 선택지 중앙화(constants)로 옵션 일관성 확보
  * 건의 전송 로직에서 선택된 장소 값을 그대로 전송하도록 변경
  * 헤더/드롭다운 z-index 유틸 추가로 레이어링 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DdingSroom/dding-sroom-frontend/pull/290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->